### PR TITLE
(chore) Add back-ups after every deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,6 +4,7 @@ name: KenyaEMR CI
   push:
     branches:
       - master
+      - chore/create-backup
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -44,6 +45,6 @@ jobs:
           password: '${{ secrets.PASSWORD }}'
           port: '${{ secrets.PORT }}'
           script: >-
-            mkdir -p /home/developers/backup && mv /var/lib/OpenMRS/frontend
-            /home/developers/backup/frontend_old_${{ github.run_number }} && mv
-            /home/developers/frontend /var/lib/OpenMRS/frontend
+            mv /var/lib/OpenMRS/frontend /var/lib/OpenMRS/frontend_old && mv
+            /home/developers/frontend /var/lib/OpenMRS/frontend && rm -rf
+            /var/lib/OpenMRS/frontend_old

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -44,6 +44,6 @@ jobs:
           password: '${{ secrets.PASSWORD }}'
           port: '${{ secrets.PORT }}'
           script: >-
-            mv /var/lib/OpenMRS/frontend /var/lib/OpenMRS/frontend_old && mv
-            /home/developers/frontend /var/lib/OpenMRS/frontend && rm -rf
-            /var/lib/OpenMRS/frontend_old
+            mkdir -p /home/developers/backup && mv /var/lib/OpenMRS/frontend
+            /home/developers/backup/frontend_old_${{ github.run_number }} && mv
+            /home/developers/frontend /var/lib/OpenMRS/frontend

--- a/delete_old_assets.sh
+++ b/delete_old_assets.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Set the backup directory path
+backup_directory="/home/developers/backup"
+
+# Find and delete assets older than 7 days
+find "$backup_directory" -type d -name "frontend_old_*" -mtime +7 -exec rm -rf {} \;

--- a/docs/cron-jon.md
+++ b/docs/cron-jon.md
@@ -1,0 +1,63 @@
+# Cron Job for Deleting Old Frontend Assets
+
+This guide explains how to set up a cron job that deletes frontend assets older than 7 days from the backup directory on your server.
+
+## Prerequisites
+
+1. A Linux-based server with access to the command line
+2. The cron utility installed on the server
+
+
+## Steps
+1. Create a shell script to delete old assets
+   
+   Create a new shell script named delete_old_assets.sh in your preferred directory on the server. Add the following content to the script:
+
+
+   ```sh
+   #!/bin/bash
+
+    # Set the backup directory path
+    backup_directory="/home/developers/backup"
+
+    # Find and delete assets older than 7 days
+    find "$backup_directory" -type d -name "frontend_old_*" -mtime +7 -exec rm -rf {} \;
+    ```
+    This script finds and deletes directories within the backup_directory that have names starting with frontend_old_ and are older than 7 days.
+
+
+2. Make the script executable
+
+    Give the script executable permissions by running the following command in the terminal:
+
+    ```sh
+    chmod +x delete_old_assets.sh
+    ```
+        
+
+3. Add a new cron entry to run the script daily
+
+    Open the crontab editor for the current user by running the following command:
+
+    
+    ```
+    crontab -e
+    ```
+
+    Add the following line at the end of the file, replacing /path/to/script with the actual path to the delete_old_assets.sh script:
+
+    ```sh
+    0 0 * * * /path/to/script/delete_old_assets.sh
+    ```
+
+    This cron entry will execute the script daily at midnight (00:00).
+
+    Save the changes and exit the editor.
+
+4. Verify the cron job
+
+    You can list your current cron jobs by running:
+
+    ```sh
+    crontab -l
+    ```


### PR DESCRIPTION
### Description

This PR aims to enhance the deployment process by creating a backup of the latest running instance before deploying a new version. This will allow us to easily roll back to the previous version in case of any issues. To manage the storage of old assets, we'll need to set up a cron job to periodically delete outdated backups. This ensures a balance between having a reliable rollback mechanism and maintaining an efficient storage system.

### Key Changes
1. Implement backup creation during deployment: Before deploying a new frontend version, the current running instance will be moved to a backup folder with a unique identifier (GitHub run number).
2. Introduce a cron job: Set up a cron job to periodically remove old backups, preventing unnecessary accumulation of outdated assets.
 