### PR TITLE
(chore) Add github action for triggering releases

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,6 +4,9 @@ name: KenyaEMR CI
   push:
     branches:
       - main
+  release:
+    types: [published]
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +18,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Use Node.js ${{ matrix.node-version }}'
         uses: actions/setup-node@v3
-      - uses: actions/checkout@v2
       - name: Run script file
         run: |
           chmod +x ./dev-build.sh
@@ -27,6 +29,38 @@ jobs:
           name: frontend
           path: |
             frontend
+
+  build_release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 18.x
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Use Node.js ${{ matrix.node-version }}'
+        uses: actions/setup-node@v3
+      - name: Run production build script
+        run: |
+          chmod +x ./prod-build.sh
+          sh ./prod-build.sh
+        shell: bash
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend_release
+          path: |
+            frontend
+
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend
       - name: Upload frontend to server
         uses: appleboy/scp-action@master
         with:
@@ -47,3 +81,33 @@ jobs:
             mv /var/lib/OpenMRS/frontend /var/lib/OpenMRS/frontend_old && mv
             /home/developers/frontend /var/lib/OpenMRS/frontend && rm -rf
             /var/lib/OpenMRS/frontend_old
+
+  release:
+    needs: [build_release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend_release
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./frontend/frontend_release.zip
+          asset_name: frontend_release.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
## Description:
Separate Build Sections for Development and Releases

This pull request introduces separate build sections for development and releases in the GitHub Actions workflow. This enhancement ensures that the development and production builds are generated with their respective scripts, dev-build.sh and prod-build.sh.

The updated workflow includes:

1. A new `build_release` job that runs only on the release event, generating production build artifacts using prod-build.sh and uploading them as frontend_release.
2. The `build` job remains unchanged and continues to generate development build artifacts using dev-build.sh.
3. The release job now depends on the `build_release` job, downloads the `frontend_release` artifacts, and uploads the frontend.zip file as a GitHub Release asset.

With these changes, development and production builds are handled separately, ensuring the appropriate build artifacts are generated and uploaded to GitHub Releases.