### PR TITLE
Fix triage form validations

### DIFF
--- a/configuration/ampathforms/Triage.json
+++ b/configuration/ampathforms/Triage.json
@@ -186,7 +186,7 @@
                   "min": "0"
                 },
                 "hide": {
-                  "hideWhenExpression": "age < 5 || age > 6 && sex !== 'F'"
+                  "hideWhenExpression": "(age > 5 && sex !== 'F') || (sex === 'F' &&  age > 49)"
                 }
               },
               {
@@ -204,7 +204,7 @@
                   }
                 ],
                 "hide": {
-                  "hideWhenExpression": "sex !== 'F' && age <= 10 || age >=49"
+                  "hideWhenExpression": "sex !== 'F'  ||  sex ==='F' && (age < 10 || age > 49)"
                 }
               },
               {
@@ -281,7 +281,7 @@
                 "id": "clientHpvVaccinated",
                 "validators": [],
                 "hide": {
-                  "hideWhenExpression": "sex !== 'F' && age >= 9 || age <= 14"
+                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
                 }
               }
             ]
@@ -364,7 +364,7 @@
                 "id": "sexualIntercourseAbstainence",
                 "validators": [],
                 "hide": {
-                  "hideWhenExpression": "sex !== 'F' && age < 10 || age >49"
+                  "hideWhenExpression": "sex !== 'F' ||sex === 'F' && (age < 10 || age > 49)"
                 }
               },
               {
@@ -445,7 +445,7 @@
                 "id": "menstrualPeriodStart",
                 "validators": [],
                 "hide": {
-                  "hideWhenExpression": "sex !== 'F' && age <= 10 || age >=49"
+                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
                 }
               },
               {
@@ -522,7 +522,7 @@
                 "id": "fpMethod",
                 "validators": [],
                 "hide": {
-                  "hideWhenExpression": "sex !== 'F' && age <= 10 || age >=49"
+                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
                 }
               },
               {
@@ -611,7 +611,7 @@
                 "id": "miscarriagePast7Days",
                 "validators": [],
                 "hide": {
-                  "hideWhenExpression": "sex !== 'F' && age <= 10 || age >=49"
+                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
                 }
               },
               {
@@ -687,7 +687,10 @@
                   "hideWhenExpression": "isEmpty(miscarriagePast7Days) || miscarriagePast7Days !== '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' "
                 }
               }
-            ]
+            ],
+            "hide": {
+              "hideWhenExpression": "sex !== 'F'"
+            }
           },
           {
             "label": "Triage Notes",
@@ -723,7 +726,7 @@
                 "id": "referClientforPregnancyTest",
                 "validators": [],
                 "hide": {
-                  "hideWhenExpression": "sex !== 'F'"
+                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
                 }
               },
               {


### PR DESCRIPTION
### Description

```
"hideWhenExpression": "sex !== 'F' || sex ==='F' && (age < 10 || age > 49)"
```

@ojwanganto @ckote @CynthiaKamau @jecihjoy tagging you along here to draw our attention to this validation logic which will hide the question in the above scenarios

1. If the user's gender is male (sex !== 'F'), the question is automatically hidden. This is because the || (OR) operator short-circuits the evaluation, and if the first part of the expression is true (in this case, when gender is male), the entire expression evaluates to true without checking the second part.


2. If the user's gender is female (sex === 'F'), the first part of the expression (sex !== 'F') fails. Therefore, we proceed to the second part of the expression. In this case, the question will be hidden if the female user's age is either less than 10 or more than 49. Essentially, the question will only be visible for female users aged 10 to 49.

