### PR TITLE
(fix) bump form-builder to correct working version

### DIFF
--- a/configuration/dev-build-config.json
+++ b/configuration/dev-build-config.json
@@ -19,7 +19,7 @@
         "@openmrs/esm-outpatient-app": "4.5.0",
         "@kenyaemr/esm-patient-registration-app": "4.4.4",
         "@openmrs/esm-patient-search-app": "4.5.0",        
-        "@openmrs/esm-form-builder-app": "1.2.0",
+        "@openmrs/esm-form-builder-app": "1.2.1-pre.426",
         "@kenyaemr/esm-patient-flags-app": "4.1.1-pre.52",
         "@openmrs/esm-patient-programs-app": "4.5.0"
     },


### PR DESCRIPTION
### Description

- Bumb `form-builder` to a correct working version. Seems to be an issue with version `1.2.0` version