### PR TITLE
(feat) update triage form with z-score/nutrional status and also validated the form

### DIFF
--- a/configuration/ampathforms/Triage.json
+++ b/configuration/ampathforms/Triage.json
@@ -1,762 +1,836 @@
 {
-    "name": "Triage",
-    "description": "Triage",
-    "version": "1",
-    "published": true,
-    "uuid": "37f6bd8d-586a-4169-95fa-5781f987fe62",
-    "retired": false,
-    "encounter": "Triage",
-    "pages": [
-      {
-        "label": "Triage",
-        "sections": [
-          {
-            "label": "Visit Details",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Date:",
-                "type": "encounterDatetime",
-                "questionOptions": {
-                  "rendering": "ui-select-extended"
+  "name": "Triage",
+  "description": "Triage",
+  "version": "1",
+  "published": true,
+  "uuid": "37f6bd8d-586a-4169-95fa-5781f987fe62",
+  "retired": false,
+  "encounter": "Triage",
+  "pages": [
+    {
+      "label": "Triage",
+      "sections": [
+        {
+          "label": "Visit Details",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Date:",
+              "type": "encounterDatetime",
+              "questionOptions": {
+                "rendering": "ui-select-extended"
+              },
+              "id": "encDate",
+              "validators": [
+                {
+                  "type": "date",
+                  "allowFutureDates": "false"
+                }
+              ]
+            },
+            {
+              "label": "Provider:",
+              "type": "encounterProvider",
+              "questionOptions": {
+                "rendering": "ui-select-extended"
+              },
+              "id": "encProvider "
+            },
+            {
+              "label": "Location:",
+              "type": "encounterLocation",
+              "questionOptions": {
+                "rendering": "ui-select-extended"
+              },
+              "id": "encLocation"
+            }
+          ]
+        },
+        {
+          "label": "Reason",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Reason for Visit:",
+              "type": "obs",
+              "id": "visitReason",
+              "questionOptions": {
+                "concept": "160430AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "textarea"
+              }
+            }
+          ]
+        },
+        {
+          "label": "Vital Signs",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Temperature (C) :",
+              "type": "obs",
+              "id": "temperature",
+              "questionOptions": {
+                "concept": "5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "43",
+                "min": "25"
+              },
+              "historicalExpression": "HD.getObject('prevEnc').getValue('5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
+            },
+            {
+              "label": "Pulse Rate:",
+              "type": "obs",
+              "id": "pulserate",
+              "questionOptions": {
+                "concept": "5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "230",
+                "min": "0"
+              }
+            },
+            {
+              "label": "Systolic BP(mmHg):",
+              "type": "obs",
+              "id": "systolicBp",
+              "questionOptions": {
+                "concept": "5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "250",
+                "min": "0"
+              }
+            },
+            {
+              "label": "Diastolic BP(mmHg):",
+              "type": "obs",
+              "id": "diastolicBp",
+              "questionOptions": {
+                "concept": "5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "150",
+                "min": "0"
+              }
+            },
+            {
+              "label": "Respiratory Rate:",
+              "type": "obs",
+              "id": "respiratoryrate",
+              "questionOptions": {
+                "concept": "5242AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "99",
+                "min": "0"
+              }
+            },
+            {
+              "label": "Oxygen Saturation:",
+              "type": "obs",
+              "id": "oxygensaturation",
+              "questionOptions": {
+                "concept": "5092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "100",
+                "min": "0"
+              }
+            }
+          ]
+        },
+        {
+          "label": "Other Recordings",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Weight(kg):",
+              "type": "obs",
+              "id": "weight",
+              "questionOptions": {
+                "concept": "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "250",
+                "min": "0"
+              }
+            },
+            {
+              "label": "Height(cm):",
+              "type": "obs",
+              "id": "height",
+              "questionOptions": {
+                "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "272",
+                "min": "10"
+              },
+              "historicalExpression": "HD.getObject('prevEnc').getValue('5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
+            },
+            {
+              "label": "BMI (Kg/m2)",
+              "type": "obs",
+              "id": "bmi",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1342AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "max": "100",
+                "min": "0",
+                "calculate": {
+                  "calculateExpression": "calcBMI(height,weight)"
+                }
+              }
+            },
+            {
+              "label": "Z-Score",
+              "type": "obs",
+              "id": "zScore",
+              "readonly": true,
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "162584AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "max": "100",
+                "min": "0",
+                "calculate": {
+                  "calculateExpression": "height && weight && fetchData(`/openmrs/ws/rest/v1/kenyaemr/zscore?sex=${sex}&age=${age}&weight=${weight}&height=${height}&type=height_for_age`,'wfl_score')"
+                }
+              },
+              "hide": {
+                "hideWhenExpression": "!(age >= 0 && age <=5)"
+              }
+            },
+            {
+              "label": "Nutritional Status",
+              "type": "obs",
+              "required": false,
+              "id": "nutritionalStatus",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "167392AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "calculate": {
+                  "calculateExpression": "zScore && calculateZNutritionScore(zScore)"
                 },
-                "id": "encDate",
-                "validators": [
+                "conceptMappings": [
                   {
-                    "type": "date",
-                    "allowFutureDates": "false"
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED NP",
+                    "value": "248358009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163515"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1115AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Normal (Median)"
+                  },
+                  {
+                    "concept": "164125AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Nutritional wasting "
+                  },
+                  {
+                    "concept": "114413AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Overweight"
+                  },
+                  {
+                    "concept": "164131AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Severe (-3 SD and -4 SD)"
+                  },
+                  {
+                    "concept": "123815AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Moderate (-2 SD)"
+                  },
+                  {
+                    "concept": "123814AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Mild (-1 SD)"
                   }
                 ]
               },
-              {
-                "label": "Provider:",
-                "type": "encounterProvider",
-                "questionOptions": {
-                  "rendering": "ui-select-extended"
-                },
-                "id": "encProvider "
-              },
-              {
-                "label": "Location:",
-                "type": "encounterLocation",
-                "questionOptions": {
-                  "rendering": "ui-select-extended"
-                },
-                "id": "encLocation"
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "!(age >= 0 && age <=5)"
               }
-            ]
-          },
-          {
-            "label": "Reason",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Reason for Visit:",
-                "type": "obs",
-                "id": "visitReason",
-                "questionOptions": {
-                  "concept": "160430AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "textarea"
-                }
+            },
+            {
+              "label": "MUAC:",
+              "type": "obs",
+              "id": "muac",
+              "questionOptions": {
+                "concept": "1343AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number",
+                "max": "250",
+                "min": "0"
+              },
+              "hide": {
+                "hideWhenExpression": "(age > 5 && sex !== 'F') || (sex === 'F' &&  age > 49)"
               }
-            ]
-          },
-          {
-            "label": "Vital Signs",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Temperature (C) :",
-                "type": "obs",
-                "id": "temperature",
-                "questionOptions": {
-                  "concept": "5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "43",
-                  "min": "25"
-                },
-                "historicalExpression": "HD.getObject('prevEnc').getValue('5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
+            },
+            {
+              "label": "LMP:",
+              "type": "obs",
+              "id": "lmpDate",
+              "questionOptions": {
+                "concept": "1427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "date"
               },
-              {
-                "label": "Pulse Rate:",
-                "type": "obs",
-                "id": "pulserate",
-                "questionOptions": {
-                  "concept": "5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "230",
-                  "min": "0"
+              "validators": [
+                {
+                  "type": "date",
+                  "allowFutureDates": "false"
                 }
-              },
-              {
-                "label": "Systolic BP(mmHg):",
-                "type": "obs",
-                "id": "systolicBp",
-                "questionOptions": {
-                  "concept": "5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "250",
-                  "min": "0"
-                }
-              },
-              {
-                "label": "Diastolic BP(mmHg):",
-                "type": "obs",
-                "id": "diastolicBp",
-                "questionOptions": {
-                  "concept": "5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "150",
-                  "min": "0"
-                }
-              },
-              {
-                "label": "Respiratory Rate:",
-                "type": "obs",
-                "id": "respiratoryrate",
-                "questionOptions": {
-                  "concept": "5242AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "99",
-                  "min": "0"
-                }
-              },
-              {
-                "label": "Oxygen Saturation:",
-                "type": "obs",
-                "id": "oxygensaturation",
-                "questionOptions": {
-                  "concept": "5092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "100",
-                  "min": "0"
-                }
+              ],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F'  ||  sex ==='F' && (age < 10 || age > 49)"
               }
-            ]
-          },
-          {
-            "label": "Other Recordings",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Weight(kg):",
-                "type": "obs",
-                "id": "weight",
-                "questionOptions": {
-                  "concept": "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "250",
-                  "min": "0"
-                }
-              },
-              {
-                "label": "Height(cm):",
-                "type": "obs",
-                "id": "height",
-                "questionOptions": {
-                  "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "272",
-                  "min": "10"
-                },
-                "historicalExpression": "HD.getObject('prevEnc').getValue('5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
-              },
-              {
-                "label": "BMI (Kg/m2)",
-                "type": "obs",
-                "id": "bmi",
-                "questionOptions": {
-                  "rendering": "number",
-                  "concept": "1342AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "max": "100",
-                  "min": "0",
-                  "calculate": {
-                    "calculateExpression": "calcBMI(height,weight)"
-                  }
-                }
-              },
-              {
-                "label": "MUAC:",
-                "type": "obs",
-                "id": "muac",
-                "questionOptions": {
-                  "concept": "1343AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "number",
-                  "max": "250",
-                  "min": "0"
-                },
-                "hide": {
-                  "hideWhenExpression": "(age > 5 && sex !== 'F') || (sex === 'F' &&  age > 49)"
-                }
-              },
-              {
-                "label": "LMP:",
-                "type": "obs",
-                "id": "lmpDate",
-                "questionOptions": {
-                  "concept": "1427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "rendering": "date"
-                },
-                "validators": [
+            },
+            {
+              "label": "Client Vaccinated against HPV?",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "160325AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
                   {
-                    "type": "date",
-                    "allowFutureDates": "false"
+                    "type": "SNOMED NP",
+                    "value": "NP: 408436009"
+                  },
+                  {
+                    "type": "CIEL",
+                    "value": "160325"
                   }
                 ],
-                "hide": {
-                  "hideWhenExpression": "sex !== 'F'  ||  sex ==='F' && (age < 10 || age > 49)"
-                }
+                "answers": [
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1066"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373067005"
+                      }
+                    ]
+                  },
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373066001"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1065"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1065"
+                      }
+                    ]
+                  }
+                ]
               },
-              {
-                "label": "Client Vaccinated against HPV?",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "160325AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "SNOMED NP",
-                      "value": "NP: 408436009"
-                    },
-                    {
-                      "type": "CIEL",
-                      "value": "160325"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "No",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1066"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373067005"
-                        }
-                      ]
-                    },
-                    {
-                      "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "Yes",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373066001"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1065"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1065"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "id": "clientHpvVaccinated",
-                "validators": [],
-                "hide": {
-                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 15)"
-                }
+              "id": "clientHpvVaccinated",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 15)"
               }
-            ]
-          },
-          {
-            "label": "Pregnancy Screening",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Have you abstained from sexual intercourse from your last menstrual period/delivery?",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "160109AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "PIH",
-                      "value": "2730"
-                    },
-                    {
-                      "type": "CIEL",
-                      "value": "160109"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "No",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1066"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373067005"
-                        }
-                      ]
-                    },
-                    {
-                      "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "Yes",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373066001"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1065"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1065"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "id": "sexualIntercourseAbstainence",
-                "validators": [],
-                "hide": {
-                  "hideWhenExpression": "sex !== 'F' ||sex === 'F' && (age < 10 || age > 49)"
-                }
-              },
-              {
-                "label": "Did your last menstrual period start within the past 7 days",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "160596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "SNOMED NP",
-                      "value": "NP: 276477006"
-                    },
-                    {
-                      "type": "LOINC",
-                      "value": "8678-5"
-                    },
-                    {
-                      "type": "CIEL",
-                      "value": "160596"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "No",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1066"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373067005"
-                        }
-                      ]
-                    },
-                    {
-                      "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "Yes",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373066001"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1065"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1065"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "id": "menstrualPeriodStart",
-                "validators": [],
-                "hide": {
-                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
-                }
-              },
-              {
-                "label": "Are you on FP method",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "160653AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "SNOMED NP",
-                      "value": "NP: 423925001"
-                    },
-                    {
-                      "type": "CIEL",
-                      "value": "160653"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "No",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1066"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373067005"
-                        }
-                      ]
-                    },
-                    {
-                      "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "Yes",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373066001"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1065"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1065"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "id": "fpMethod",
-                "validators": [],
-                "hide": {
-                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
-                }
-              },
-              {
-                "label": "Have you had a miscarriage in the past 7 days",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "48AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "ICD-10-WHO",
-                      "value": "O03.9"
-                    },
-                    {
-                      "type": "AMPATH",
-                      "value": "48"
-                    },
-                    {
-                      "type": "CIEL",
-                      "value": "48"
-                    },
-                    {
-                      "type": "PIH",
-                      "value": "48"
-                    },
-                    {
-                      "type": "SNOMED CT",
-                      "value": "CT: 17369002"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "No",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1066"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373067005"
-                        }
-                      ]
-                    },
-                    {
-                      "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "Yes",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373066001"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1065"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1065"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "id": "miscarriagePast7Days",
-                "validators": [],
-                "hide": {
-                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
-                }
-              },
-              {
-                "label": "Have you had a baby in the last 4 weeks?",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "1657AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "CIEL",
-                      "value": "1657"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "No",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1066"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1066"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373067005"
-                        }
-                      ]
-                    },
-                    {
-                      "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "label": "Yes",
-                      "conceptMappings": [
-                        {
-                          "type": "PIH",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "SNOMED CT",
-                          "value": "CT: 373066001"
-                        },
-                        {
-                          "type": "PIH Malawi",
-                          "value": "Malawi: 1065"
-                        },
-                        {
-                          "type": "CIEL",
-                          "value": "1065"
-                        },
-                        {
-                          "type": "AMPATH",
-                          "value": "1065"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "id": "hadBabyInLast4Weeks",
-                "validators": [],
-                "hide": {
-                  "hideWhenExpression": "isEmpty(miscarriagePast7Days) || miscarriagePast7Days !== '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' "
-                }
-              }
-            ],
-            "hide": {
-              "hideWhenExpression": "sex !== 'F'"
             }
-          },
-          {
-            "label": "Triage Notes",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Did you refer the client for a Pregnancy test? ",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "1648AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "CIEL",
-                      "value": "1648"
-                    },
-                    {
-                      "type": "SNOMED CT",
-                      "value": "CT: 309018005"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "label": "Yes",
-                      "concept": "true"
-                    },
-                    {
-                      "label": "No",
-                      "concept": "false"
-                    }
-                  ]
-                },
-                "id": "referClientforPregnancyTest",
-                "validators": [],
-                "hide": {
-                  "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
-                }
+          ]
+        },
+        {
+          "label": "Pregnancy Screening",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Have you abstained from sexual intercourse from your last menstrual period/delivery?",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "160109AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "PIH",
+                    "value": "2730"
+                  },
+                  {
+                    "type": "CIEL",
+                    "value": "160109"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1066"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373067005"
+                      }
+                    ]
+                  },
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373066001"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1065"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1065"
+                      }
+                    ]
+                  }
+                ]
               },
-              {
-                "label": "Triage Notes:",
-                "type": "obs",
-                "questionOptions": {
-                  "rendering": "text",
-                  "concept": "160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  "conceptMappings": [
-                    {
-                      "type": "CIEL",
-                      "value": "160632"
-                    },
-                    {
-                      "type": "AMPATH",
-                      "value": "1915"
-                    },
-                    {
-                      "type": "LOINC",
-                      "value": "48767-8"
-                    }
-                  ]
-                },
-                "id": "triageNotes"
+              "id": "sexualIntercourseAbstainence",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' ||sex === 'F' && (age < 10 || age > 49)"
               }
-            ]
+            },
+            {
+              "label": "Did your last menstrual period start within the past 7 days",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "160596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "SNOMED NP",
+                    "value": "NP: 276477006"
+                  },
+                  {
+                    "type": "LOINC",
+                    "value": "8678-5"
+                  },
+                  {
+                    "type": "CIEL",
+                    "value": "160596"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1066"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373067005"
+                      }
+                    ]
+                  },
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373066001"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1065"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1065"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "id": "menstrualPeriodStart",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
+              }
+            },
+            {
+              "label": "Are you on FP method",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "160653AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "SNOMED NP",
+                    "value": "NP: 423925001"
+                  },
+                  {
+                    "type": "CIEL",
+                    "value": "160653"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1066"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373067005"
+                      }
+                    ]
+                  },
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373066001"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1065"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1065"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "id": "fpMethod",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
+              }
+            },
+            {
+              "label": "Have you had a miscarriage in the past 7 days",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "48AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "ICD-10-WHO",
+                    "value": "O03.9"
+                  },
+                  {
+                    "type": "AMPATH",
+                    "value": "48"
+                  },
+                  {
+                    "type": "CIEL",
+                    "value": "48"
+                  },
+                  {
+                    "type": "PIH",
+                    "value": "48"
+                  },
+                  {
+                    "type": "SNOMED CT",
+                    "value": "CT: 17369002"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1066"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373067005"
+                      }
+                    ]
+                  },
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373066001"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1065"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1065"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "id": "miscarriagePast7Days",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
+              }
+            },
+            {
+              "label": "Have you had a baby in the last 4 weeks?",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "1657AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "CIEL",
+                    "value": "1657"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1066"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1066"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373067005"
+                      }
+                    ]
+                  },
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes",
+                    "conceptMappings": [
+                      {
+                        "type": "PIH",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "SNOMED CT",
+                        "value": "CT: 373066001"
+                      },
+                      {
+                        "type": "PIH Malawi",
+                        "value": "Malawi: 1065"
+                      },
+                      {
+                        "type": "CIEL",
+                        "value": "1065"
+                      },
+                      {
+                        "type": "AMPATH",
+                        "value": "1065"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "id": "hadBabyInLast4Weeks",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(miscarriagePast7Days) || miscarriagePast7Days !== '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' "
+              }
+            }
+          ],
+          "hide": {
+            "hideWhenExpression": "sex !== 'F'"
           }
-        ]
-      }
-    ],
-    "processor": "EncounterFormProcessor",
-    "referencedForms": []
-  }
+        },
+        {
+          "label": "Triage Notes",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Did you refer the client for a Pregnancy test? ",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "1648AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "CIEL",
+                    "value": "1648"
+                  },
+                  {
+                    "type": "SNOMED CT",
+                    "value": "CT: 309018005"
+                  }
+                ],
+                "answers": [
+                  {
+                    "label": "Yes",
+                    "concept": "true"
+                  },
+                  {
+                    "label": "No",
+                    "concept": "false"
+                  }
+                ]
+              },
+              "id": "referClientforPregnancyTest",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || sex === 'F' && (age < 10 || age > 49)"
+              }
+            },
+            {
+              "label": "Triage Notes:",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "CIEL",
+                    "value": "160632"
+                  },
+                  {
+                    "type": "AMPATH",
+                    "value": "1915"
+                  },
+                  {
+                    "type": "LOINC",
+                    "value": "48767-8"
+                  }
+                ]
+              },
+              "id": "triageNotes"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "processor": "EncounterFormProcessor",
+  "referencedForms": [],
+  "encounterType": "d1059fb9-a079-4feb-a749-eedd709ae542"
+}


### PR DESCRIPTION
### Description

This PR achieve two main objectives namely
1. Add `zscore` and `nutrional status` question for patient below the age of 5. @ckote please verify this is correct.
2. Validate the other concept to be working as expected.

cc @makombe @ojwanganto 

#### **ticket**
https://thepalladiumgroup.atlassian.net/browse/KHP3-3865