### PR TITLE
KHP3-3723 : (enhc) Complete validation of `HTS Eligibility Screening Form`

### DIFF
--- a/configuration/ampathforms/HTS_Eligibility_Screening.json
+++ b/configuration/ampathforms/HTS_Eligibility_Screening.json
@@ -1,6 +1,6 @@
 {
   "name": "HTS Eligibility Screening Form",
-  "description": "HTS Eligibility Screening Form",
+  "description": "Form used to screen clients prior to HIV testing",
   "version": "1",
   "published": true,
   "uuid": "04295648-7606-11e8-adc0-fa7ae01bbebc",
@@ -803,11 +803,11 @@
                 "rendering": "radio",
                 "answers": [
                   {
-                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "1",
                     "label": "Yes"
                   },
                   {
-                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "0",
                     "label": "No"
                   },
                   {
@@ -844,7 +844,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9"
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '0' || age < 9"
               }
             },
             {
@@ -871,7 +871,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9 "
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '0' || age < 9 "
               }
             },
             {
@@ -902,7 +902,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 10 "
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '0' || age < 10 "
               }
             },
             {
@@ -929,7 +929,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 10"
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1' || age < 10"
               }
             },
             {
@@ -941,22 +941,18 @@
                 "rendering": "radio",
                 "answers": [
                   {
-                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "1",
                     "label": "Yes"
                   },
                   {
-                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "0",
                     "label": "No"
-                  },
-                  {
-                    "concept": "162570AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "label": "Declined to answer"
                   }
                 ]
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9"
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1' || age < 9"
               }
             },
             {
@@ -969,7 +965,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(multipleSexPartners) || multipleSexPartners !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9"
+                "hideWhenExpression": "isEmpty(multipleSexPartners) || multipleSexPartners !== '1' || age < 9"
               }
             },
             {
@@ -1000,7 +996,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9"
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1' || age < 9"
               }
             },
             {
@@ -1027,7 +1023,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9"
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1' || age < 9"
               }
             },
             {
@@ -1054,7 +1050,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9"
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1' || age < 9"
               }
             },
             {
@@ -1081,7 +1077,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9 "
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1' || age < 9 "
               }
             },
             {
@@ -1108,7 +1104,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9 "
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive !== '1' || age < 9 "
               }
             },
             {
@@ -1131,7 +1127,7 @@
               },
               "validators": [],
               "hide": {
-                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || age < 9 "
+                "hideWhenExpression": "isEmpty(sexuallyActive) || sexuallyActive == '0' || age < 9 "
               }
             },
             {
@@ -1176,55 +1172,55 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression":"testedResultsprovider === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+                "hideWhenExpression": "testedResultsprovider === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
               }
             },
-                {
-                  "label": "For children if any of the below are present , explore with the guardian and determine HTS eligibility",
-                  "type": "obs",
-                  "id": "EligiBiliTykiDs",
-                  "questionOptions": {
-                    "concept": "165908AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "rendering": "checkbox",
-                    "answers": [
-                      {
-                        "concept": "115122AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "Malnutrition"
-                      },
-                      {
-                        "concept": "5050AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "Failure to thrive (age and child's growth rate has discrepancy)"
-                      },
-                      {
-                        "concept": "127833AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "Recurrent infections"
-                      },
-                      {
-                        "concept": "112141AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "TB"
-                      },
-                      {
-                        "concept": "1174AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "No parent (are orphaned)"
-                      },
-                      {
-                        "concept": "163718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "Parents /siblings who recently tested HIV positive."
-                      },
-                      {
-                        "concept": "140238AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "Prolonged fever of unknown origin"
-                      },
-                      {
-                        "concept": "5632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "label": "Children >18 months who are still breastfeeding or wet nursing"
-                      }
-                    ]
+            {
+              "label": "For children if any of the below are present , explore with the guardian and determine HTS eligibility",
+              "type": "obs",
+              "id": "EligiBiliTykiDs",
+              "questionOptions": {
+                "concept": "165908AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "checkbox",
+                "answers": [
+                  {
+                    "concept": "115122AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Malnutrition"
                   },
-                  "hide": {
-                    "hideWhenExpression": "age > 9 || testedResultsprovider === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+                  {
+                    "concept": "5050AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Failure to thrive (age and child's growth rate has discrepancy)"
+                  },
+                  {
+                    "concept": "127833AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Recurrent infections"
+                  },
+                  {
+                    "concept": "112141AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "TB"
+                  },
+                  {
+                    "concept": "1174AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No parent (are orphaned)"
+                  },
+                  {
+                    "concept": "163718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Parents /siblings who recently tested HIV positive."
+                  },
+                  {
+                    "concept": "140238AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Prolonged fever of unknown origin"
+                  },
+                  {
+                    "concept": "5632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Children >18 months who are still breastfeeding or wet nursing"
                   }
-                }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "age > 9 || testedResultsprovider === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
+            }
           ]
         },
         {
@@ -1361,7 +1357,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression":"testedResultsprovider === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+                "hideWhenExpression": "testedResultsprovider === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
               }
             },
             {
@@ -1373,11 +1369,11 @@
                 "rendering": "radio",
                 "answers": [
                   {
-                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "1",
                     "label": "Yes"
                   },
                   {
-                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "0",
                     "label": "No"
                   }
                 ]
@@ -1439,7 +1435,7 @@
               "type": "obs",
               "id": "screenedTB",
               "questionOptions": {
-                "concept": "165197AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "concept": "cddbf6fe-4bcd-40b6-a7ea-8573e4080192",
                 "rendering": "radio",
                 "answers": [
                   {
@@ -1511,11 +1507,11 @@
                 "rendering": "radio",
                 "answers": [
                   {
-                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "1",
                     "label": "Yes"
                   },
                   {
-                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "0",
                     "label": "No"
                   }
                 ]
@@ -1534,11 +1530,11 @@
                 "rendering": "radio",
                 "answers": [
                   {
-                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "1",
                     "label": "Yes"
                   },
                   {
-                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "0",
                     "label": "No"
                   }
                 ]
@@ -1628,7 +1624,7 @@
             },
             {
               "label": "Get HIV Risk Score :",
-              "type": "obs",
+              "type": "control",
               "id": "getHIVRiskScore",
               "questionOptions": {
                 "concept": "160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -1671,7 +1667,7 @@
               "type": "obs",
               "id": "reCommeNHiVtest",
               "questionOptions": {
-                "concept": "164410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "concept": "167229AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "radio",
                 "answers": [
                   {
@@ -1837,5 +1833,6 @@
     }
   ],
   "processor": "EncounterFormProcessor",
-  "referencedForms": []
+  "referencedForms": [],
+  "encounterType": "9c0a7a57-62ff-4f75-babe-5835b0e921b7"
 }


### PR DESCRIPTION
### Description
ticket https://thepalladiumgroup.atlassian.net/browse/KHP3-3723

In this Pull Request, I've enhanced the form so that it's now capable of saving data properly. It's crucial to mention a particular transformation that has been implemented: the mapping of boolean concepts. In our current setup, the boolean value `1` corresponds to `1065`, and `0` is equivalent to `1066`.

 @ckote I kindly request your in-depth review and insightful feedback on these modifications. If possible pay with it on our test instance.
 
 Consequently we will have to remap this changes to `ML` variables