### PR TITLE
(enhc) Add config to disable registering unidentified patient

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -317,7 +317,8 @@
     },
     "fieldConfigurations": {
       "name": {
-        "displayCapturePhoto": false
+        "displayCapturePhoto": false,
+        "allowUnidentifiedPatients": false
       },
       "dateOfBirth": {
         "useEstimatedDateOfBirth": {

--- a/configuration/prod-config.json
+++ b/configuration/prod-config.json
@@ -318,7 +318,7 @@
     "fieldConfigurations": {
       "name": {
         "displayCapturePhoto": false,
-        "displayKnownNameToggle": false
+        "allowUnidentifiedPatients": false
       },
       "dateOfBirth": {
         "useEstimatedDateOfBirth": {

--- a/dev-build.sh
+++ b/dev-build.sh
@@ -8,7 +8,7 @@ rm -rf frontend
 # Build assets
 echo "Building Kenya EMR 3.x assets ..."
 CWD=$(pwd)
-npx --legacy-peer-deps openmrs@5.0.3-pre.863 build \
+npx --legacy-peer-deps openmrs@next build \
   --build-config ./configuration/dev-build-config.json \
   --target ./frontend \
   --page-title "KenyaEMR" \
@@ -16,7 +16,7 @@ npx --legacy-peer-deps openmrs@5.0.3-pre.863 build \
 
 # Assemble assets
 echo "Assembling assets ..."
-npx --legacy-peer-deps openmrs@5.0.3-pre.863 assemble \
+npx --legacy-peer-deps openmrs@next assemble \
   --manifest \
   --mode config \
   --config ./configuration/dev-build-config.json \


### PR DESCRIPTION
### Description

This PR add configuration to disable registration of unidentified patient, by setting the property `allowUnidentifiedPatients` to false
see the attached screenshot

### Screenshot
![Unidentifier patient](https://github.com/palladiumkenya/openmrs-config-kenyaemr/assets/28008754/abb80832-706d-4499-920c-66525f4c8021)

