### PR TITLE
(fix) follow up on triage form to fix min/max on z-score to accomodate negative numbers

### DIFF
--- a/configuration/ampathforms/Triage.json
+++ b/configuration/ampathforms/Triage.json
@@ -184,7 +184,7 @@
                 "rendering": "number",
                 "concept": "162584AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "max": "100",
-                "min": "0",
+                "min": "-50",
                 "calculate": {
                   "calculateExpression": "height && weight && fetchData(`/openmrs/ws/rest/v1/kenyaemr/zscore?sex=${sex}&age=${age}&weight=${weight}&height=${height}&type=height_for_age`,'wfl_score')"
                 }


### PR DESCRIPTION
### Description

This should have been part of [121](https://github.com/palladiumkenya/openmrs-config-kenyaemr/pull/121) but was left out.
It is to allow validation to work since z-score almost always has a negative number