### PR TITLE
(chore) add `esm-dispensing-app` to dev config

### DIFF
--- a/configuration/dev-build-config.json
+++ b/configuration/dev-build-config.json
@@ -25,11 +25,12 @@
         "@kenyaemr/esm-patient-flags-app": "next",
         "@kenyaemr/esm-version-app": "next",
         "@kenyaemr/esm-care-panel-app": "next",
-        "@openmrs/esm-patient-orders-app":"next",
-        "@openmrs/esm-patient-immunizations-app":"next",
-        "@openmrs/esm-patient-attachments-app":"next",
-        "@openmrs/esm-patient-medications-app":"next",
-        "@openmrs/esm-patient-test-results-app":"next"
+        "@openmrs/esm-patient-orders-app": "next",
+        "@openmrs/esm-patient-immunizations-app": "next",
+        "@openmrs/esm-patient-attachments-app": "next",
+        "@openmrs/esm-patient-medications-app": "next",
+        "@openmrs/esm-patient-test-results-app": "next",
+        "@openmrs/esm-dispensing-app": "next"
     },
     "spaPath": "/openmrs/spa",
     "apiUrl": "/openmrs",


### PR DESCRIPTION
### What does this PR do

This PR adds `esm-dispensing-app` to our dev-config. This is to enable QA and internal testing since the upgrade to platform 2.6.0.


cc @ojwanganto @CynthiaKamau @Valuoch @makombe 