### PR TITLE
Removed duplicated hide validation

### DIFF
--- a/configuration/ampathforms/HIV_Discontinuation.json
+++ b/configuration/ampathforms/HIV_Discontinuation.json
@@ -126,9 +126,6 @@
                 "concept": "1543AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "date"
               },
-              "hide": {
-                "hideWhenExpression": "isEmpty(idReason) || idReason !== '160034AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-              },
               "validators": [
                 {
                   "type": "date",


### PR DESCRIPTION
Removed duplicated hide validations on the HIV Discontinuation form under date of death