### PR TITLE
(fix) Fix failing HIV enrollment form due to boolean concept

### DIFF
--- a/configuration/ampathforms/HIV_Enrollment.json
+++ b/configuration/ampathforms/HIV_Enrollment.json
@@ -560,7 +560,7 @@
                     "rendering": "checkbox",
                     "answers": [
                       {
-                        "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "concept": "true",
                         "label": "Yes"
                       }
                     ]


### PR DESCRIPTION
### What does this PR do?

Update `HIV Enrollment form` to use boolean `true` concept