### PR TITLE
(enhc) Update progress note to be textarea

### DIFF
--- a/configuration/ampathforms/Progress_Note.json
+++ b/configuration/ampathforms/Progress_Note.json
@@ -56,7 +56,8 @@
               "required": true,
               "id": "note",
               "questionOptions": {
-                "rendering": "text",
+                "rendering": "textarea",
+                "rows": 5,
                 "concept": "159395AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "answers": []
               },


### PR DESCRIPTION
### What does this PR do?

This PR updates progress note form `Notes` question to be `textarea` 