### PR TITLE
(fix) HTS Eligibility and HIV Enrollment forms

### DIFF
--- a/configuration/ampathforms/HIV_Enrollment.json
+++ b/configuration/ampathforms/HIV_Enrollment.json
@@ -1459,9 +1459,16 @@
                   "id": "tsTelephone",
                   "questionOptions": {
                     "concept": "160642AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "rendering": "number",
+                    "rendering": "text",
                     "min": "0"
-                  }
+                  },
+                  "validators": [
+                    {
+                      "type": "js_expression",
+                      "failsWhenExpression": "doesNotMatchExpression('^0([0-9](?:(?:[0-9][0-9])|(?:0[0-8])|(4[0-1]))[0-9]{6})$', tsTelephone)",
+                      "message": "Invalid phone number, please enter number in the format 0000000000 example 0720200200"
+                    }
+                  ]
                 },
                 {
                   "label": "Postal address",

--- a/configuration/ampathforms/HTS_Eligibility_Screening.json
+++ b/configuration/ampathforms/HTS_Eligibility_Screening.json
@@ -362,10 +362,6 @@
                     "label": "Social Contact"
                   },
                   {
-                    "concept": "166517AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "label": "Needle Sharing"
-                  },
-                  {
                     "concept": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "None"
                   }


### PR DESCRIPTION
### What does this PR do?

This PR updates HTS Eligibility to remove `Needle sharing` concept which causes the form to fail while submitting, Update HIV enrollment form by rendering correct phone number and placing validation to ensure correct phone number are captured.

@ckote @mmatheka please confirm the issue with HTS `Needle sharing` concept.