### PR TITLE
(fix) Add expected appointment config section

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -395,6 +395,9 @@
       }
     }
   },
+  "expected-appointments-panel": {
+    "title": "Scheduled"
+  },
   "@openmrs/esm-patient-labs-app": {
     "concepts": [
       {

--- a/configuration/prod-config.json
+++ b/configuration/prod-config.json
@@ -395,6 +395,9 @@
       }
     }
   },
+  "expected-appointments-panel": {
+    "title": "Scheduled"
+  },
   "@openmrs/esm-patient-labs-app": {
     "concepts": [
       {


### PR DESCRIPTION
This config overrides the default string of the scheduled appointments tab which read Expected