### PR TITLE
HTS eligibility screening form, for positive clients, the TB section

### DIFF
--- a/configuration/ampathforms/HTS_Eligibility_Screening.json
+++ b/configuration/ampathforms/HTS_Eligibility_Screening.json
@@ -1458,9 +1458,6 @@
                     "label": "No"
                   }
                 ]
-              },
-              "hide": {
-                "hideWhenExpression": "testedResultsprovider === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
               }
             },
             {


### PR DESCRIPTION
HTS eligibility screening form, for positive clients, the TB section is hidden hence the user can’t screen for TB.