### PR TITLE
Weight, BMI, and height indicator appearing at HIV enrollment form

### DIFF
--- a/configuration/ampathforms/HIV_Enrollment.json
+++ b/configuration/ampathforms/HIV_Enrollment.json
@@ -1234,49 +1234,7 @@
                 "hideWhenExpression": "patientType === '4bd29eed-e486-426d-a2b6-7e5bb75319f6' || patientType === '159833AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || sex !== 'F'"
               }
             },
-            {
-              "label": "Weight (Kg)",
-              "type": "obs",
-              "id": "weight",
-              "required": "true",
-              "questionOptions": {
-                "concept": "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "rendering": "number",
-                "min": "0"
-              },
-              "hide": {
-                "hideWhenExpression": "patientType === '4bd29eed-e486-426d-a2b6-7e5bb75319f6' || patientType === '159833AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-              }
-            },
-            {
-              "label": "Height(cm)",
-              "type": "obs",
-              "id": "height",
-              "required": "true",
-              "questionOptions": {
-                "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "rendering": "number",
-                "min": "0"
-              },
-              "hide": {
-                "hideWhenExpression": "patientType === '4bd29eed-e486-426d-a2b6-7e5bb75319f6' || patientType === '159833AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-              }
-            },
-            {
-              "label": "BMI",
-              "type": "obs",
-              "id": "bodyMassIndex",
-              "questionOptions": {
-                "rendering": "number",
-                "concept": "1342AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "calculate": {
-                  "calculateExpression": "calcBMI(height,weight)"
-                }
-              },
-              "hide": {
-                "hideWhenExpression": "patientType === '4bd29eed-e486-426d-a2b6-7e5bb75319f6' || patientType === '159833AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-              }
-            },
+      
             {
               "label": "MUAC",
               "type": "obs",


### PR DESCRIPTION
Weight, BMI, and height indicator appearing at HIV enrollment form and its mandatory field. Instead it should be at triaging.