### PR TITLE
(fix) Make `how many sexual partners` have a max and min values for validation

### DIFF
--- a/configuration/ampathforms/HTS_Eligibility_Screening_Revised.json
+++ b/configuration/ampathforms/HTS_Eligibility_Screening_Revised.json
@@ -980,8 +980,8 @@
               "questionOptions": {
                 "concept": "5570AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "number",
-                "max": 1000,
-                "min": 0
+                "max": "10000",
+                "min": "0"
               },
               "validators": [],
               "hide": {


### PR DESCRIPTION
### Description

Make `how many sexual partners` to have `max` and `min` properties to enable validation