### PR TITLE
(feat) Update primary nav config to use custom `app-menu`

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -10,6 +10,14 @@
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
       "src": "/openmrs/spa/kenyaemr-primary-logo.svg"
+    },
+    "extensionSlots": {
+      "app-menu-slot": {
+        "remove": [
+          "dispensing-link",
+          "system-administration-app-menu-link"
+        ]
+      }
     }
   },
   "@openmrs/esm-patient-programs-app": {
@@ -26,10 +34,15 @@
   "@openmrs/esm-patient-chart-app": {
     "extensionSlots": {
       "patient-highlights-bar-slot": {
-        "remove": ["patient-flag-tags"]
+        "remove": [
+          "patient-flag-tags"
+        ]
       },
       "patient-chart-summary-dashboard-slot": {
-        "remove": ["biometrics-overview-widget", "vitals-overview-widget"]
+        "remove": [
+          "biometrics-overview-widget",
+          "vitals-overview-widget"
+        ]
       }
     },
     "showServiceQueueFields": true,
@@ -54,7 +67,9 @@
   "@openmrs/esm-home-app": {
     "extensionSlots": {
       "homepage-widgets-slot": {
-        "remove": ["home-appointments"]
+        "remove": [
+          "home-appointments"
+        ]
       }
     }
   },
@@ -78,7 +93,11 @@
       {
         "id": "custom",
         "name": "Demographics",
-        "fields": ["maritalStatus", "occupation", "education"]
+        "fields": [
+          "maritalStatus",
+          "occupation",
+          "education"
+        ]
       },
       {
         "id": "contact",
@@ -366,7 +385,9 @@
       "statusConceptSetUuid": "9484732b-bcaf-429e-86cb-d6cf3da34211",
       "defaultStatusConceptUuid": "167407AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "defaultTransitionStatus": "167408AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-      "historicalObsConceptUuid": ["161643AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]
+      "historicalObsConceptUuid": [
+        "161643AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      ]
     },
     "visitQueueNumberAttributeUuid": "c61ce16f-272a-41e7-9924-4c555d0932c5",
     "showQueueTableTab": true,
@@ -389,8 +410,12 @@
     "showUnscheduledAppointmentsTab": true,
     "extensionSlots": {
       "scheduled-appointments-panels-slot": {
-        "add": ["early-appointments-panel"],
-        "remove": ["cancelled-appointments-panel"],
+        "add": [
+          "early-appointments-panel"
+        ],
+        "remove": [
+          "cancelled-appointments-panel"
+        ],
         "configure": {
           "early-appointments-panel": {
             "showForPastDate": true,

--- a/configuration/prod-config.json
+++ b/configuration/prod-config.json
@@ -10,6 +10,14 @@
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
       "src": "/openmrs/spa/kenyaemr-primary-logo.svg"
+    },
+    "extensionSlots": {
+      "app-menu-slot": {
+        "remove": [
+          "dispensing-link",
+          "system-administration-app-menu-link"
+        ]
+      }
     }
   },
   "@openmrs/esm-patient-programs-app": {
@@ -26,10 +34,15 @@
   "@openmrs/esm-patient-chart-app": {
     "extensionSlots": {
       "patient-highlights-bar-slot": {
-        "remove": ["patient-flag-tags"]
+        "remove": [
+          "patient-flag-tags"
+        ]
       },
       "patient-chart-summary-dashboard-slot": {
-        "remove": ["biometrics-overview-widget","vitals-overview-widget"]
+        "remove": [
+          "biometrics-overview-widget",
+          "vitals-overview-widget"
+        ]
       }
     },
     "showServiceQueueFields": true,
@@ -54,7 +67,9 @@
   "@openmrs/esm-home-app": {
     "extensionSlots": {
       "homepage-widgets-slot": {
-        "remove": ["home-appointments"]
+        "remove": [
+          "home-appointments"
+        ]
       }
     }
   },
@@ -78,7 +93,11 @@
       {
         "id": "custom",
         "name": "Demographics",
-        "fields": ["maritalStatus", "occupation", "education"]
+        "fields": [
+          "maritalStatus",
+          "occupation",
+          "education"
+        ]
       },
       {
         "id": "contact",
@@ -366,7 +385,9 @@
       "statusConceptSetUuid": "9484732b-bcaf-429e-86cb-d6cf3da34211",
       "defaultStatusConceptUuid": "167407AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "defaultTransitionStatus": "167408AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-      "historicalObsConceptUuid": ["161643AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]
+      "historicalObsConceptUuid": [
+        "161643AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      ]
     },
     "visitQueueNumberAttributeUuid": "c61ce16f-272a-41e7-9924-4c555d0932c5",
     "showQueueTableTab": true,
@@ -389,8 +410,12 @@
     "showUnscheduledAppointmentsTab": true,
     "extensionSlots": {
       "scheduled-appointments-panels-slot": {
-        "add": ["early-appointments-panel"],
-        "remove": ["cancelled-appointments-panel"],
+        "add": [
+          "early-appointments-panel"
+        ],
+        "remove": [
+          "cancelled-appointments-panel"
+        ],
         "configure": {
           "early-appointments-panel": {
             "showForPastDate": true,


### PR DESCRIPTION
### Description:

We have updated our app menu implementation to be a custom in this [PR](https://github.com/palladiumkenya/kenyaemr-esm-3.x/pull/59). Following this PR being merged we need to disable community provided App Menu, by removing the two extension slots attached by default to app menu. 

### Screenshots
<img width="928" alt="Screenshot 2024-01-01 at 23 13 24" src="https://github.com/palladiumkenya/openmrs-config-kenyaemr/assets/28008754/bc87d909-88af-42fb-a527-d8b9afb9b5d3">
