### PR TITLE
(fix) Update config to escape literal

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -397,7 +397,7 @@
       "f85081e2-b4be-4e48-b3a4-7994b69bb101"
     ],
     "defaultFacilityUrl": "/ws/rest/v1/kenyaemr/default-facility",
-    "customPatientChartUrl": "\${openmrsSpaBase}/patient/${patientUuid}/chart",
+    "customPatientChartUrl": "${openmrsSpaBase}/patient/${patientUuid}/chart",
     "customPatientIdUrl": "/ws/rest/v1/kenyaemr/patient?patientUuid",
     "customPatientChartText": "2.X Profile"
   },


### PR DESCRIPTION
### Description

The currect patient chart url config for service queue is not correct. Setting it up correctly