### PR TITLE
(fix) update MAT forms should have `retired` property in JSON

### DIFF
--- a/configuration/ampathforms/MAT_Discontinuation_Form.json
+++ b/configuration/ampathforms/MAT_Discontinuation_Form.json
@@ -4,6 +4,7 @@
   "uuid": "38d6e116-b96c-4916-a821-b4dc83e2041d",
   "processor": "EncounterFormProcessor",
   "published": true,
+  "retired": false,
   "referencedForms": [],
   "encounter": "MAT Discontinuation Encounter",
   "version": "1",

--- a/configuration/ampathforms/MAT_Initial_Registration_Form.json
+++ b/configuration/ampathforms/MAT_Initial_Registration_Form.json
@@ -3,6 +3,7 @@
   "description": "Initial Registration Form",
   "uuid": "9a9cadd7-fba1-4a24-94aa-43edfbecf8d9",
   "published": true,
+  "retired": false,
   "processor": "EncounterFormProcessor",
   "referencedForms": [],
   "version": "1.0",

--- a/configuration/ampathforms/MAT_Patient_Treatment_Form.json
+++ b/configuration/ampathforms/MAT_Patient_Treatment_Form.json
@@ -3,6 +3,7 @@
   "description": "MAT Patient Treatment Form",
   "processor": "EncounterFormProcessor",
   "published": true,
+  "retired": false,
   "uuid": "350d93cd-66da-4b7e-ae9a-fdfdc9195add",
   "referencedForms": [],
   "version": "1.0",

--- a/configuration/ampathforms/MAT_Psychiatric_Intake_and_Follow_up_Form.json
+++ b/configuration/ampathforms/MAT_Psychiatric_Intake_and_Follow_up_Form.json
@@ -4,6 +4,7 @@
   "uuid": "cfd2109b-63b3-43de-8bb3-682e80c5a965",
   "processor": "EncounterFormProcessor",
   "published": true,
+  "retired": false,
   "referencedForms": [],
   "version": "1",
   "encounter": "MAT Psychiatric intake and followup",

--- a/configuration/ampathforms/MAT_Psychosocial_Follow_Up_Form.json
+++ b/configuration/ampathforms/MAT_Psychosocial_Follow_Up_Form.json
@@ -5,6 +5,7 @@
   "uuid": "6c5be9ea-46d2-4281-af44-f2a8e2d5260c",
   "referencedForms": [],
   "published": true,
+  "retired": false,
   "version": "1.0",
   "encounter": "MAT Psychosocial intake and followup",
   "pages": [

--- a/configuration/ampathforms/MAT_Transit_Referral_Form.json
+++ b/configuration/ampathforms/MAT_Transit_Referral_Form.json
@@ -5,6 +5,7 @@
   "version": "1",
   "processor": "EncounterFormProcessor",
   "published": true,
+  "retired": false,
   "referencedForms": [],
   "encounter": "MAT Transit/Referral Encounter",
   "pages": [


### PR DESCRIPTION
## Description

Update forms to include the `retired` property