### PR TITLE
(feat) disable check in appointments and let users use start visit form for checkin

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -57,16 +57,15 @@
               "privileges": ["o3: View Family History"]
             }
           },
-          "billing-summary-dashboard-link":{
+          "billing-summary-dashboard-link": {
             "Display conditions": {
               "privileges": ["o3: View Billing"]
             }
           },
-          "clinical-view-section":{
+          "clinical-view-section": {
             "Display conditions": {
               "privileges": ["o3: View Care Panels"]
             }
-          
           }
         }
       },
@@ -518,6 +517,9 @@
           }
         }
       }
+    },
+    "checkInButton": {
+      "enabled": false
     },
     "Display conditions": {
       "privileges": ["o3: View Appointments"]


### PR DESCRIPTION
### Description

This PR adds config to disable the `Check In` appointments button on `esm-appointments` dashboard and let users use the patient chart start visit form for checking in appointments. cc @ojwanganto 