### PR TITLE
(feat) Add Social Health Insurance Number as default identifier types

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -156,7 +156,8 @@
       "6428800b-5a8c-4f77-a285-8d5f6174e5fb",
       "b4d66522-11fc-45c7-83e3-39a1af21ae0d",
       "be9beef6-aacc-4e1f-ac4e-5babeaa1e303",
-      "ca125004-e8af-445d-9436-a43684150f8b"
+      "ca125004-e8af-445d-9436-a43684150f8b",
+      "52c3c0c3-05b8-4b26-930e-2a6a54e14c90"
     ],
     "sections": [
       "demographics",


### PR DESCRIPTION
### Description:

This PR adds Social Health Insurance Number as one of the default patient identifier types under identifiers on patient registration page.


This is related to this [PR](https://github.com/palladiumkenya/openmrs-module-kenyaemr/pull/1855)