### PR TITLE
HTS Retest form changes

### DIFF
--- a/configuration/ampathforms/HTS_Retest.json
+++ b/configuration/ampathforms/HTS_Retest.json
@@ -33,7 +33,7 @@
               "label": "HTS Provider",
               "type": "encounterProvider",
               "questionOptions": {
-                "rendering": "encounter-provider"
+                "rendering": "ui-select-extended"
               },
               "id": "encounterProvider"
             },
@@ -41,7 +41,7 @@
               "label": "Facility name",
               "type": "encounterLocation",
               "questionOptions": {
-                "rendering": "encounter-location"
+                "rendering": "ui-select-extended"
               },
               "id": "encounterLocation"
             }
@@ -984,13 +984,13 @@
               }
             },
             {
-              "label": "HIV Test(s)",
+              "label": "HIV Test",
               "type": "obsGroup",
               "questionOptions": {
                 "rendering": "group",
                 "concept": "164410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
               },
-              "id": "hivTest",
+              "id": "hivTest1",
               "validators": [],
               "hide": {
                 "hideWhenExpression": "isEmpty(consentGiven) || consentGiven !== 'true'"
@@ -1120,7 +1120,22 @@
                   "hide": {
                     "hideWhenExpression": "isEmpty(kitName) && isEmpty(kitNameA) && isEmpty(kitNameFe)"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "label": "HIV Test(s)",
+              "type": "obsGroup",
+              "questionOptions": {
+                "rendering": "group",
+                "concept": "164410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "hivTest2",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(consentGiven) || consentGiven !== 'true'"
+              },
+              "questions": [
                 {
                   "label": "Kit 2 Name",
                   "type": "obs",
@@ -1129,7 +1144,7 @@
                     "concept": "214c83f9-435d-44f5-9ae6-d5757b7b4c7f",
                     "answers": [
                       {
-                        "concept": "59ef8c87-eb66-4f9e-a459-7227c01f682e",
+                        "concept": "66ee72aa-7639-4f79-ab97-ef2eaadda7c0",
                         "label": "One Step"
                       }
                     ]
@@ -1182,7 +1197,7 @@
                   "type": "obs",
                   "questionOptions": {
                     "rendering": "select",
-                    "concept": "1040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "1326AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "answers": [
                       {
                         "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -1203,7 +1218,22 @@
                   "hide": {
                     "hideWhenExpression": "isEmpty(kitNameB)"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "label": "HIV Test",
+              "type": "obsGroup",
+              "questionOptions": {
+                "rendering": "group",
+                "concept": "164410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "hivTestA2",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(consentGiven) || consentGiven !== 'true'"
+              },
+              "questions": [
                 {
                   "label": "Kit 1 Name",
                   "type": "obs",
@@ -1269,7 +1299,7 @@
                   "type": "obs",
                   "questionOptions": {
                     "rendering": "select",
-                    "concept": "1040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "1326AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "answers": [
                       {
                         "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -1290,7 +1320,22 @@
                   "hide": {
                     "hideWhenExpression": "isEmpty(kitNameD)"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "label": "HIV Test",
+              "type": "obsGroup",
+              "questionOptions": {
+                "rendering": "group",
+                "concept": "164410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "hivTest3",
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(consentGiven) || consentGiven !== 'true'"
+              },
+              "questions": [
                 {
                   "label": "Kit 3 Name",
                   "type": "obs",
@@ -1352,7 +1397,7 @@
                   "type": "obs",
                   "questionOptions": {
                     "rendering": "select",
-                    "concept": "1040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "concept": "83038d41-e832-498b-928f-974ec5bb23dc",
                     "answers": [
                       {
                         "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -1494,11 +1539,6 @@
                   }
                 ],
                 "answers": [
-                  {
-                    "concept": "c3eba392-6f4d-4990-809f-91000503afbc",
-                    "label": "Couple",
-                    "disableWhenExpression": "myValue === '1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-                  },
                   {
                     "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Yes",


### PR DESCRIPTION
## Description
1. Grouping of the tests
2. Dropping of the couple as an option under the 'Couple is discordant' question.
3. Aligning the encounter location and provider details