### PR TITLE
(chore) revert to using the community version for dispensing module

### DIFF
--- a/configuration/dev-build-config.json
+++ b/configuration/dev-build-config.json
@@ -25,7 +25,7 @@
     "@kenyaemr/esm-patient-flags-app": "next",
     "@kenyaemr/esm-version-app": "next",
     "@kenyaemr/esm-care-panel-app": "next",
-    "@kenyaemr/esm-dispensing-app": "next",
+    "@openmrs/esm-dispensing-app": "next",
     "@kenyaemr/esm-billing-app": "next",
     "@openmrs/esm-stock-management-app": "next",
     "@kenyaemr/esm-laboratory-app": "next",


### PR DESCRIPTION
## Description

As part of moving work on integration between dispensing medication and stock levels I am reverting the dispensing module back to the community version. cc @RAJABIBRAZ @Murithijoshua @makombe @ojwanganto if we generate assets for production. Let's use the prod config to track what version we are shipping.