### PR TITLE
HTS Initial Form Changes

### DIFF
--- a/configuration/ampathforms/HTS_Initial.json
+++ b/configuration/ampathforms/HTS_Initial.json
@@ -33,7 +33,7 @@
               "label": "HTS Provider",
               "type": "encounterProvider",
               "questionOptions": {
-                "rendering": "encounter-provider"
+                "rendering": "ui-select-extended"
               },
               "id": "encounterProvider"
             },
@@ -41,7 +41,7 @@
               "label": "Facility name",
               "type": "encounterLocation",
               "questionOptions": {
-                "rendering": "encounter-location"
+                "rendering": "ui-select-extended"
               },
               "id": "encounterLocation"
             }
@@ -1103,11 +1103,8 @@
                       {
                         "concept": "59ef8c87-eb66-4f9e-a459-7227c01f682e",
                         "label": "First Response"
-                      },
-                      {
-                        "concept": "2f5a80fa-6f26-4832-b8a8-f47649bb60de",
-                        "label": "Dual Kit"
                       }
+                     
                     ]
                   },
                   "id": "kitNameB",


### PR DESCRIPTION
### Description

1. Change Location and Provider ID on HTS Eligibility, rendering should be "ui-select-extended" and not what we have "encounter-location".
2. Drop Dual kit for test 2 as it's not used to confirm results.