### PR TITLE
HTS Retest Form Changes

### DIFF
--- a/configuration/ampathforms/HTS_Retest.json
+++ b/configuration/ampathforms/HTS_Retest.json
@@ -1103,11 +1103,8 @@
                       {
                         "concept": "59ef8c87-eb66-4f9e-a459-7227c01f682e",
                         "label": "First Response"
-                      },
-                      {
-                        "concept": "2f5a80fa-6f26-4832-b8a8-f47649bb60de",
-                        "label": "Dual Kit"
                       }
+                      
                     ]
                   },
                   "id": "kitNameB",


### PR DESCRIPTION
### Description
Drop 'Dual Kit' not to appear under HIV test 2.