### PR TITLE
MCH_Antenatal Form changes

### DIFF
--- a/configuration/ampathforms/MCH_Antenatal_form.json
+++ b/configuration/ampathforms/MCH_Antenatal_form.json
@@ -339,11 +339,8 @@
 						{
 						  "concept": "59ef8c87-eb66-4f9e-a459-7227c01f682e",
 						  "label": "First Response"
-						},
-						{
-						  "concept": "2f5a80fa-6f26-4832-b8a8-f47649bb60de",
-						  "label": "Dual Kit"
 						}
+						
 					  ]
 					},
 					"id": "kitNameB",
@@ -460,6 +457,54 @@
 					  "label": "No"
 					}
 				  ]
+				}
+			  },
+			  {
+				"label": "Syphilis serology:",
+				"type": "obs",
+				"id": "syphilisTestResults",
+				"questionOptions": {
+				  "concept": "299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				  "rendering": "select",
+				  "answers": [
+					{
+					  "concept": "1229AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+					  "label": "Negative"
+					},
+					{
+					  "concept": "1228AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+					  "label": "Positive"
+					},
+					{
+					  "concept": "1304AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+					  "label": "Poor Sample quality"
+					}
+				  ]
+				},
+				"hide": {
+				  "hideWhenExpression": "isEmpty(kitName) || kitName !== '2f5a80fa-6f26-4832-b8a8-f47649bb60de'"
+				}
+			  },
+			  {
+				"label": "Has the client been treated for syphilis?",
+				"type": "obs",
+				"id": "syphilisTreated",
+				"questionOptions": {
+				  "concept": "159918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				  "rendering": "radio",
+				  "answers": [
+					{
+					  "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+					  "label": "Yes"
+					},
+					{
+					  "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+					  "label": "No"
+					}
+				  ]
+				},
+				"hide": {
+				  "hideWhenExpression": "syphilisTestResults !== '1228AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
 				}
 			  },
 			  {


### PR DESCRIPTION
### Description

1. Drop Dual test not to appear as Test kit used for HIV test 2.
2. Add Syphilis serology results and treatment if the kit used for testing is Dual.  