### PR TITLE
MCH_Postnatal Form changes

### DIFF
--- a/configuration/ampathforms/MCH_Postnatal_Visit.json
+++ b/configuration/ampathforms/MCH_Postnatal_Visit.json
@@ -757,10 +757,7 @@
                         "concept": "7cf927f8-e734-474f-b71a-1459bb566aa2",
                         "label": "Determine"
                       },
-                      {
-                        "concept": "59ef8c87-eb66-4f9e-a459-7227c01f682e",
-                        "label": "First Response"
-                      },
+                     
                       {
                         "concept": "2f5a80fa-6f26-4832-b8a8-f47649bb60de",
                         "label": "Dual Kit"
@@ -839,18 +836,12 @@
                     "rendering": "select",
                     "concept": "214c83f9-435d-44f5-9ae6-d5757b7b4c7f",
                     "answers": [
-                      {
-                        "concept": "7cf927f8-e734-474f-b71a-1459bb566aa2",
-                        "label": "Determine"
-                      },
+                      
                       {
                         "concept": "59ef8c87-eb66-4f9e-a459-7227c01f682e",
                         "label": "First Response"
-                      },
-                      {
-                        "concept": "2f5a80fa-6f26-4832-b8a8-f47649bb60de",
-                        "label": "Dual Kit"
                       }
+                      
                     ]
                   },
                   "id": "kitNameB",
@@ -970,6 +961,54 @@
               },
               "hide": {
                 "hideWhenExpression": "isEmpty(hivFinalResult)"
+              }
+            },
+            {
+              "label": "Syphilis serology:",
+              "type": "obs",
+              "id": "syphilisTestResults",
+              "questionOptions": {
+                "concept": "299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "1229AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "1228AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "1304AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Poor Sample quality"
+                  }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "isEmpty(kitName) || kitName !== '2f5a80fa-6f26-4832-b8a8-f47649bb60de'"
+              }
+            },
+            {
+              "label": "Has the client been treated for syphilis?",
+              "type": "obs",
+              "id": "syphilisTreated",
+              "questionOptions": {
+                "concept": "159918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "radio",
+                "answers": [
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No"
+                  }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "syphilisTestResults !== '1228AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
               }
             },
             {


### PR DESCRIPTION
### Description

1. Validate Dual Kit to be available for HIV test 1 and only to have first response for HIV test 2 (Confirmatory).
2. Add Syphilis serology test to appear if Dual kit is selected.