### PR TITLE
(feat) add config to remove community lab order pickup action

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -880,20 +880,6 @@
       "privileges": ["o3: View referrals"]
     }
   },
-  "@kenyaemr/esm-laboratory-app": {
-    "extensionSlots": {
-      "lab-panels-slot": {
-        "remove": [
-          "referred-panel-component",
-          "review-panel-component",
-          "approved-panel-component"
-        ]
-      }
-    },
-    "Display conditions": {
-      "privileges": ["o3: View Labs"]
-    }
-  },
   "@kenyaemr/esm-bed-management-app": {
     "patientListForAdmissionUrl": "/ws/rest/v1/kenyaemr/sql?q=bedManagement.sqlGet.patientListForAdmission",
     "admissionLocationTagUuid": "0815e0b2-1182-4157-9340-bee371ea41e4"
@@ -915,6 +901,13 @@
         "city": "Village",
         "district": "County",
         "state": "Sub county"
+      }
+    }
+  },
+  "@openmrs/esm-laboratory-app": {
+    "extensionSlots": {
+      "tests-ordered-actions-slot": {
+        "remove": ["pick-lab-request-action"]
       }
     }
   }


### PR DESCRIPTION
## Description

In our instance, we want to enforce billing for lab tech to proceed to perform the test. This config, removes the community instance that doesn't enforce this mechanism, we have also migrated to community version of lab order making the exisiting `@kenyaemrs/esm-lab-app` config useless.

