### PR TITLE
(fix) expand `maxDispenseDurationInDays` for drug order to enable drug order

### DIFF
--- a/configuration/dev-config.json
+++ b/configuration/dev-config.json
@@ -724,7 +724,7 @@
     }
   },
   "@openmrs/esm-patient-medications-app": {
-    "maxDispenseDurationInDays": 185,
+    "maxDispenseDurationInDays": 365,
     "Display conditions": {
       "privileges": ["o3: View Medications"]
     }


### PR DESCRIPTION
### Description

This PR allows clinicians to place medication orders for periods longer than 185 days. This change is based on feedback from the Machakos Level 5 pilot, where patients receiving six-month medication supplies faced issues with expiry dates coinciding with holidays such as Christmas or Easter. To address this, additional days have been included to ensure continuity of medication supply during these periods.

cc @andrineM @ojwanganto @makombe 