### PR TITLE
(fix) : revert to version 8.0.0 for patient labs

### DIFF
--- a/frontend-config/staging/build-config.json
+++ b/frontend-config/staging/build-config.json
@@ -16,7 +16,7 @@
     "@openmrs/esm-patient-notes-app": "8.2.0",
     "@openmrs/esm-patient-attachments-app": "8.2.0",
     "@openmrs/esm-patient-medications-app": "8.2.0",
-    "@openmrs/esm-patient-labs-app": "8.2.0",
+    "@openmrs/esm-patient-labs-app": "8.0.0",
     "@openmrs/esm-patient-chart-app": "8.2.0",
     "@openmrs/esm-laboratory-app": "1.0.1-pre.392",
     "@openmrs/esm-dispensing-app": "1.5.1-pre.332",


### PR DESCRIPTION
### Description

Latest version of patient lab has breaking changes preventing use of `results-viewer` tab for lab. This PR reverts to a previous working version

cc @palladiumkenya/qa @mmatheka @ckote @ErickSomie 
This should address the challenge with Nyeri Instance cc @mmatheka 