### PR TITLE
(fix) : allow effective discontinuation date to be saved correctly

### DIFF
--- a/configuration/ampathforms/HIV_Discontinuation.json
+++ b/configuration/ampathforms/HIV_Discontinuation.json
@@ -10,7 +10,7 @@
     "programs": {
       "uuid": "dfdc6d40-2f2f-463d-ba90-cc97350441a8",
       "isEnrollment": false,
-      "discontinuationDateQuestionId": "discontinueDate"
+      "discontinuationDateQuestionId": ""
     }
   },
   "pages": [


### PR DESCRIPTION
## Description

This PR resolves an issue with the effective discontinuation date, which was incorrectly tied to the dateCompleted on the program enrollment endpoint. It uncouples these two fields to ensure they are recorded correctly. Additionally, if the discontinuedDate field is not specified in the form, the form engine will automatically use the current date and time as the dateCompleted.

cc @andrineM @palladiumkenya/qa @mmatheka this should resolve the discontinuation issue.