### PR TITLE
(chore) default to build KDOD registration config

### DIFF
--- a/.github/workflows/deployment_8500_spa.yml
+++ b/.github/workflows/deployment_8500_spa.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Execute Development Build Script
         run: |
           chmod +x ./dev-build.sh
-          echo "n" | ./dev-build.sh
+          echo "y" | ./dev-build.sh
 
       - name: Compress frontend folder
         run: tar -czvf frontend-${{ github.sha }}.tar.gz frontend/


### PR DESCRIPTION
### Description

Since KDOD registration is an extension to whats already deployed. Having it as the default for registration should not be a block cc @palladiumkenya/qa @mmatheka