### PR TITLE
(fix) KHP3-7037 : MCH Delivery Form: Fix Visit Date/Time Validation to Ensure Dates Fall Within Valid Range

### DIFF
--- a/configuration/ampathforms/Delivery.json
+++ b/configuration/ampathforms/Delivery.json
@@ -171,7 +171,7 @@
 			  },
 			  {
 				"label": "Date of Delivery:",
-				"type": "encounterDatetime",
+				"type": "obs",
 				"questionOptions": {
 				  "rendering": "date",
 				  "concept": "5599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"


### PR DESCRIPTION
### Description 

This PR resolves an issue with the delivery date field, which was incorrectly assigned the type encounterDate instead of obs. This type mismatch caused the form engine to generate incorrect payloads on each submission. With this fix, the form engine now processes the delivery date accurately.

## Screenshot
Error that has been reported
![Screenshot 2024-11-05 at 22 18 05](https://github.com/user-attachments/assets/ed2da35d-d203-401d-a7d3-d4868c99544c)
