### PR TITLE
Fix prep intial form failing to save

### DIFF
--- a/configuration/ampathforms/PrEP_Initial.json
+++ b/configuration/ampathforms/PrEP_Initial.json
@@ -52,7 +52,7 @@
 			"questions": [
 			  {
 				"label": "Partner HIV positive?:",
-				"type": "encounterDatetime",
+				"type": "obs",
 				"questionOptions": {
 				  "rendering": "radio",
 				  "answers": [


### PR DESCRIPTION
@ckote @ErickSomie @mmatheka `"type": "encounterDatetime",`  Please take note the encounter date time type should only be used on the visit date and **NOT** on any other questions within the form.