### PR TITLE
(feat) KHP3-7139 : Make `Add complain field` mandatory in the clinical encounter form

### DIFF
--- a/configuration/ampathforms/clinical-encounter.json
+++ b/configuration/ampathforms/clinical-encounter.json
@@ -145,7 +145,8 @@
               "id": "ComplaintLodgeByClient",
               "questionOptions": {
                 "concept": "160531AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "rendering": "repeating"
+                "rendering": "repeating",
+                "min": 1
               },
               "validators": [],
               "hide": {
@@ -155,6 +156,7 @@
                 {
                   "label": "Complaint",
                   "type": "obs",
+                  "required": "true",
                   "id": "cOmplaIntField",
                   "questionOptions": {
                     "concept": "5219AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -474,6 +476,7 @@
                 {
                   "label": "Specify other complaints",
                   "type": "obs",
+                  "required": "true",
                   "id": "OtherSpecificComplaints",
                   "questionOptions": {
                     "concept": "20395601-257c-490c-86c2-acffb627f91f",
@@ -524,6 +527,7 @@
                   "label": "Duration (Days)",
                   "type": "obs",
                   "id": "complaint-duration",
+                  "required": "true",
                   "questionOptions": {
                     "concept": "159368AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "rendering": "number",
@@ -531,7 +535,6 @@
                   },
                   "validators": []
                 },
-               
                 {
                   "label": "Onset Status",
                   "type": "obs",
@@ -2131,7 +2134,6 @@
                     "label": "Lethargic",
                     "disableWhenExpression": "myValue === '1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
                   },
-                 
                   {
                     "concept": "135488AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Lymphadenopathy",
@@ -2167,7 +2169,6 @@
                     "label": "Restless",
                     "disableWhenExpression": "myValue === '1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
                   },
-                 
                   {
                     "concept": "823AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Wasting",
@@ -2232,7 +2233,6 @@
                 "concept": "164448AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "radio",
                 "answers": [
-                  
                   {
                     "concept": "1362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "+"
@@ -2496,7 +2496,6 @@
                 "concept": "5245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "radio",
                 "answers": [
-                  
                   {
                     "concept": "160361AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Anterior cervical"
@@ -3001,7 +3000,6 @@
                 "hideWhenExpression": "isEmpty(allsystemReview) || !arrayContains(allsystemReview, '119235AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
               }
             },
-
             {
               "label": "Eyes findings",
               "type": "obs",
@@ -3614,7 +3612,6 @@
                 "hideWhenExpression": "isEmpty(counsellingOrderd) || !arrayContains(counsellingOrderd, '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
               }
             },
-          
             {
               "label": "Patient Outcome ",
               "type": "obs",


### PR DESCRIPTION
### Description
https://thepalladiumgroup.atlassian.net/browse/KHP3-7139

cc @mmatheka @ErickSomie @ckote 

For repeating questions, where we need to make it a mandatory field, we have to specify the `min` number of the repeated questions and mark the questions as `required` in this case

```json
{
  "label": "Presenting complaints",
  "type": "obsGroup",
  "id": "ComplaintLodgeByClient",
  "questionOptions": {
    "concept": "160531AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
    "rendering": "repeating",
    "min": 1
  },
  "validators": [],
  "hide": {
    "hideWhenExpression": "complaintsToday !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
  },
  "questions": [
    {
      "label": "Complaint",
      "type": "obs",
      "required": "true",
      "id": "cOmplaIntField",
      "questionOptions": {
        "concept": "5219AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
        "rendering": "select",
        "answers": [
          {
            "concept": "151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
            "label": "Abdominal pain"
          },
          {
            "concept": "141631AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
            "label": "Abnormal Uterine Bleeding"
          }
        ]
      }
    }
  ]
}
```

**NB** 
```json
"questionOptions": {
    "concept": "160531AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
    "rendering": "repeating",
    "min": 1
  }
```

has an additional `min` property that will always ensure we capture at least one instance of the repeating questions