### PR TITLE
Make referral for preventive services mandatory in HTS Initial.

### DIFF
--- a/configuration/ampathforms/HTS_Initial.json
+++ b/configuration/ampathforms/HTS_Initial.json
@@ -1648,6 +1648,7 @@
             {
               "label": "Client referred for other services:",
               "type": "obs",
+              "required": "true",
               "questionOptions": {
                 "rendering": "radio",
                 "concept": "c9404c8f-cf83-4bfe-acc0-4881599c78ba",
@@ -1678,6 +1679,7 @@
                 {
                   "label": "Referred for which services::",
                   "type": "obs",
+                  "required": "true",
                   "questionOptions": {
                     "rendering": "checkbox",
                     "concept": "1272AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",


### PR DESCRIPTION
### Description
Put checks to ensure HIV-negative client is linked to prevention services in HTS initial referral section. Make this part mandatory.