### PR TITLE
Child enrollment form CWC number validation.

### DIFF
--- a/configuration/ampathforms/Mch_Child_Enrolment.json
+++ b/configuration/ampathforms/Mch_Child_Enrolment.json
@@ -246,7 +246,7 @@
             },
             {
               "type": "patientIdentifier",
-              "label": "CWC No (CWC-MFL code-serial number) e.g CWC-15007-00001",
+              "label": "CWC No (CWC-MFL code-year-serial number) e.g CWC-15007-2025-00001",
               "questionInfo": "",
               "id": "CwcFormat",
               "required": "true",
@@ -258,8 +258,8 @@
               "validators": [
                 {
                   "type": "js_expression",
-                  "failsWhenExpression": "doesNotMatchExpression('^CWC-\\\\d{5}-\\\\d{5,6}$', CwcFormat)",
-                  "message": "Please provide the correct format for the cwc number ie. CWC+mflCode+number eg.CWC-11902-00062"
+                  "failsWhenExpression": "doesNotMatchExpression('^CWC-\\\\d{5}-\\\\d{4}-\\\\d{5,6}$', CwcFormat)",
+                  "message": "Please provide the correct format for the cwc number ie. CWC+mflCode+year-number eg.CWC-11902-2025-00062"
                 }
               ]
             },


### PR DESCRIPTION
### Description
CWC number format will always be a duplicate due to client with a similar serial number previous years – relax the validation and include the year.