### PR TITLE
Drop 'Other' as a population from the HTS Eligibility screening form.

### DIFF
--- a/configuration/ampathforms/HTS_Eligibility_Screening.json
+++ b/configuration/ampathforms/HTS_Eligibility_Screening.json
@@ -93,30 +93,16 @@
                   {
                     "concept": "162277AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "People in prison or enclosed spaces"
-                  },
-                 
-                  {
-                    "concept": "5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "label": "Other"
                   }
+                 
+                 
                 ]
               },
               "hide": {
                 "hideWhenExpression": "populationType !== 'bf850dd4-309b-4cbd-9470-9d8110ea5550' || age <15 || sex != 'F'"
               }
             },
-            {
-              "label": "Specify:",
-              "type": "obs",
-              "questionOptions": {
-                "rendering": "text",
-                "concept": "163761AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-              },
-              "id": "kPfmalEOther",
-              "hide": {
-                "hideWhenExpression": "isEmpty(kpTypeFemale) || kpTypeFemale !== '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-              }
-            },
+            
             {
               "label": "Key Population Type :",
               "type": "obs",


### PR DESCRIPTION
### Description
Drop 'Other' as a population from the HTS Eligibility screening form. This is to avoid users recording any other unacceptable typology under Key population.