### PR TITLE
Change the concept IDs for the PEP question in HTS Eligibility form.

### DIFF
--- a/configuration/ampathforms/HTS_Eligibility_Screening.json
+++ b/configuration/ampathforms/HTS_Eligibility_Screening.json
@@ -122,30 +122,16 @@
                   {
                     "concept": "162277AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "People in prison or enclosed spaces"
-                  },
-                  
-                  {
-                    "concept": "5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "label": "Other"
                   }
+                  
+                  
                 ]
               },
               "hide": {
                 "hideWhenExpression": "populationType !== 'bf850dd4-309b-4cbd-9470-9d8110ea5550' || age <15 || sex != 'M'"
               }
             },
-            {
-              "label": "Specify:",
-              "type": "obs",
-              "questionOptions": {
-                "rendering": "text",
-                "concept": "163761AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-              },
-              "id": "kPmalEOther",
-              "hide": {
-                "hideWhenExpression": "isEmpty(kpTypeMale) || kpTypeMale !== '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-              }
-            },
+            
             {
               "label": "Priority Population Type :",
               "type": "obs",
@@ -1406,15 +1392,15 @@
               "type": "obs",
               "id": "currentlyPep",
               "questionOptions": {
-                "concept": "1691AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "concept": "d3f845d4-3a6a-447e-9c68-89a32830071d",
                 "rendering": "radio",
                 "answers": [
                   {
-                    "concept": "1",
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Yes"
                   },
                   {
-                    "concept": "0",
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "No"
                   },
                   {


### PR DESCRIPTION
### Description
Change the concept IDs for the PEP question in HTS Eligibility form to allow saving of the form.
Drop 'Other' from the key population typologies.