### PR TITLE
Clinical encounter validations to accept No for complaints

### DIFF
--- a/configuration/ampathforms/clinical-encounter.json
+++ b/configuration/ampathforms/clinical-encounter.json
@@ -471,7 +471,10 @@
                         "label": "Other"
                       }
                     ]
-                  }
+                  },
+                  "hide": {
+                "hideWhenExpression": "complaintsToday !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
                 },
                 {
                   "label": "Specify other complaints",
@@ -526,14 +529,16 @@
                 {
                   "label": "Duration (Days)",
                   "type": "obs",
-                  "id": "complaint-duration",
+                  "id": "complaintduration",
                   "required": "true",
                   "questionOptions": {
                     "concept": "159368AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "rendering": "number",
                     "min": "0"
                   },
-                  "validators": []
+                  "hide": {
+                "hideWhenExpression": "complaintsToday !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
                 },
                 {
                   "label": "Onset Status",
@@ -552,7 +557,10 @@
                         "label": "Sudden"
                       }
                     ]
-                  }
+                  },
+                  "hide": {
+                "hideWhenExpression": "complaintsToday !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
                 }
               ]
             },


### PR DESCRIPTION
### Description
Check on the validations on *Clinical Encounter Form* It won't take *No* for an answer. Validate the presenting complaints questions to allow saving if "No" is selected.