### PR TITLE
fix: add missing commas to metadata CSV to fix column count error

### DIFF
--- a/configuration/metadatatermmappings/metadatatermmappings.csv
+++ b/configuration/metadatatermmappings/metadatatermmappings.csv
@@ -1,11 +1,12 @@
 Uuid,Void/Retire,Mapping code,Mapping source,Metadata class name,Metadata Uuid,_order:2000
 b7c8adf5-c875-4e78-bb4b-fea391b1de55,,emr.primaryIdentifierType,org.openmrs.module.emrapi,org.openmrs.PatientIdentifierType,05a29f94-c0ed-11e2-94be-8c13b969e334,
 d5b1abfd-3f1c-4489-bc48-318018407b47,,emr.extraPatientIdentifierTypes,org.openmrs.module.emrapi,org.openmrs.module.metadatamapping.MetadataSet,f0ebcb99-7618-41b7-b0bf-8ff93de67b9e,
-e1a1b2c3-d4e5-6789-0abc-def123456789,,emr.admissionEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,e22e39fd-7db2-45e7-80f1-60fa0d5a4378
-f2b3c4d5-e6f7-8901-2bcd-ef3456789012,,emr.exitFromInpatientEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,181820aa-88c9-479b-9077-af92f5364329
-a3c4d5e6-f7g8-9012-3cde-f45678901234,,emr.transferWithinHospitalEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,d3b07384-8d1c-4e6b-9b8e-2f3b8e4a1c9f
-b4d5e6f7-g8h9-0123-4def-567890123456,,emr.inpatientNoteEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,a1f5c3d2-4b6e-4e8a-9f2d-1b3e8e4a2d7f
-c5e6f7g8-h9i0-1234-5ef0-678901234567,,emr.transferRequestEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,b2c4d5e6-7f8a-4e9b-8c1d-2e3f8e4a3b8f
-c9d6f8e2-3b4a-4e6b-9f8e-1a2b3c4d5e6f,,emr.clinicianEncounterRole,org.openmrs.module.emrapi,org.openmrs.EncounterRole,240b26f9-dd88-4172-823d-4a8bfeb7841f
-d039435f-233a-4d0b-a35a-75450b2e65b9,,emr.bedAssignmentEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,f47ac10b-58cc-4372-a567-0e02b2c3d479
-e9ae298d-532c-4f72-93c1-a42495270662,,emr.cancelADTRequestEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,550e8400-e29b-41d4-a716-446655440000
+e1a1b2c3-d4e5-6789-0abc-def123456789,,emr.admissionEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,e22e39fd-7db2-45e7-80f1-60fa0d5a4378,
+f2b3c4d5-e6f7-8901-2bcd-ef3456789012,,emr.exitFromInpatientEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,181820aa-88c9-479b-9077-af92f5364329,
+a3c4d5e6-f7g8-9012-3cde-f45678901234,,emr.transferWithinHospitalEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,d3b07384-8d1c-4e6b-9b8e-2f3b8e4a1c9f,
+b4d5e6f7-g8h9-0123-4def-567890123456,,emr.inpatientNoteEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,a1f5c3d2-4b6e-4e8a-9f2d-1b3e8e4a2d7f,
+c5e6f7g8-h9i0-1234-5ef0-678901234567,,emr.transferRequestEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,b2c4d5e6-7f8a-4e9b-8c1d-2e3f8e4a3b8f,
+c9d6f8e2-3b4a-4e6b-9f8e-1a2b3c4d5e6f,,emr.clinicianEncounterRole,org.openmrs.module.emrapi,org.openmrs.EncounterRole,240b26f9-dd88-4172-823d-4a8bfeb7841f,
+d039435f-233a-4d0b-a35a-75450b2e65b9,,emr.bedAssignmentEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,f47ac10b-58cc-4372-a567-0e02b2c3d479,
+e9ae298d-532c-4f72-93c1-a42495270662,,emr.cancelADTRequestEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,550e8400-e29b-41d4-a716-446655440000,
+efe66933-eeb3-4aa3-8cb8-501f82361c48,,emr.visitNoteEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,d7151f82-c1f3-4152-a605-2f9ea7414a79,


### PR DESCRIPTION
### What’s been changed?

1. Fixed malformed rows: Added missing trailing commas to ensure every row has 7 columns, consistent with the header.

Added `emr.visitNoteEncounterType`
```csv
efe66933eeb3-4aa3-8cb8-501f82361c48,,emr.visitNoteEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,d7151f82-c1f3-4152-a605-2f9ea7414a79,
```