### PR TITLE
Fix: Update emr.primaryIdentifierType mapping to correct UUID

### DIFF
--- a/configuration/metadatatermmappings/metadatatermmappings.csv
+++ b/configuration/metadatatermmappings/metadatatermmappings.csv
@@ -1,5 +1,5 @@
 Uuid,Void/Retire,Mapping code,Mapping source,Metadata class name,Metadata Uuid,_order:2000
-b7c8adf5-c875-4e78-bb4b-fea391b1de55,,emr.primaryIdentifierType,org.openmrs.module.emrapi,org.openmrs.PatientIdentifierType,05a29f94-c0ed-11e2-94be-8c13b969e334,
+b7c8adf5-c875-4e78-bb4b-fea391b1de55,,emr.primaryIdentifierType,org.openmrs.module.emrapi,org.openmrs.PatientIdentifierType,dfacd928-0370-4315-99d7-6ec1c9f7ae76,
 d5b1abfd-3f1c-4489-bc48-318018407b47,,emr.extraPatientIdentifierTypes,org.openmrs.module.emrapi,org.openmrs.module.metadatamapping.MetadataSet,f0ebcb99-7618-41b7-b0bf-8ff93de67b9e,
 e1a1b2c3-d4e5-6789-0abc-def123456789,,emr.admissionEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,e22e39fd-7db2-45e7-80f1-60fa0d5a4378,
 f2b3c4d5-e6f7-8901-2bcd-ef3456789012,,emr.exitFromInpatientEncounterType,org.openmrs.module.emrapi,org.openmrs.EncounterType,181820aa-88c9-479b-9077-af92f5364329,


### PR DESCRIPTION
### Description

Updated the `emr.primaryIdentifierType` metadata mapping from the default UUID `05a29f94-c0ed-11e2-94be-8c13b969e334` to the implementation-specific UUID `dfacd928-0370-4315-99d7-6ec1c9f7ae76`.

This ensures that the primary patient identifier type used in our implementation resolves correctly and aligns with our custom configuration. This fix helps prevent potential runtime issues when referencing the primary identifier in patient workflows.

### Screenshot
![Screenshot from 2025-04-16 17-14-02](https://github.com/user-attachments/assets/9b5af06f-1901-468d-a2b9-7dbbc1f4a00c)

Notice that **OpenMRS** is bold
