### PR TITLE
Auto-populate LMP date in the Delivery form.

### DIFF
--- a/configuration/ampathforms/Delivery.json
+++ b/configuration/ampathforms/Delivery.json
@@ -91,6 +91,8 @@
 				"id": "lastLmpDate",
 				"questionOptions": {
 				  "concept": "1427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				  "useMostRecentValue": true,
+                "autoPopulateWithMostRecentValue": true,
 				  "rendering": "date"
 				},
 				"validators": [


### PR DESCRIPTION
### Description
Auto-populate the variables already captured in the previous forms. This are the variables that won't change for the current pregnancy. They are :
> LMP
> Estimated Date of delivery