### PR TITLE
Remove billing links extensions from billing-dashboard-group-nav-slot avoiding duplication

### DIFF
--- a/frontend-config/dev/kenyaemr.config.json
+++ b/frontend-config/dev/kenyaemr.config.json
@@ -507,15 +507,7 @@
                 }
             },
             "billing-dashboard-group-nav-slot": {
-                "add": [
-                    "billing-overview-link",
-                    "payment-history-link",
-                    "payment-points-link",
-                    "payment-modes-link",
-                    "bill-manager-link",
-                    "chargeable-items-link",
-                    "billable-exemptions-link"
-                ],
+                "add": [],
                 "configure": {
                     "billable-exemptions-link": {
                         "Display conditions": {

--- a/frontend-config/prod/kenyaemr.config.json
+++ b/frontend-config/prod/kenyaemr.config.json
@@ -470,15 +470,7 @@
                 }
             },
             "billing-dashboard-group-nav-slot": {
-                "add": [
-                    "billing-overview-link",
-                    "payment-history-link",
-                    "payment-points-link",
-                    "payment-modes-link",
-                    "bill-manager-link",
-                    "chargeable-items-link",
-                    "billable-exemptions-link"
-                ],
+                "add": [],
                 "configure": {
                     "billable-exemptions-link": {
                         "Display conditions": {

--- a/frontend-config/staging/kenyaemr.config.json
+++ b/frontend-config/staging/kenyaemr.config.json
@@ -575,15 +575,7 @@
                 }
             },
             "billing-dashboard-group-nav-slot": {
-                "add": [
-                    "billing-overview-link",
-                    "payment-history-link",
-                    "payment-points-link",
-                    "payment-modes-link",
-                    "bill-manager-link",
-                    "chargeable-items-link",
-                    "billable-exemptions-link"
-                ],
+                "add": [],
                 "configure": {
                     "billable-exemptions-link": {
                         "Display conditions": {


### PR DESCRIPTION
Since we define the slotes from source code, having them here caused duplication of billing links