### PR TITLE
age validation on the menopause question to only appear for 40 and above

### DIFF
--- a/configuration/ampathforms/HIV_Green_Card.json
+++ b/configuration/ampathforms/HIV_Green_Card.json
@@ -2397,7 +2397,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "sex !=='F' || (age < 10 || age > 49)"
+                "hideWhenExpression": "sex !=='F' || (age < 40 || age > 49)"
               }
             },
             {


### PR DESCRIPTION
This PR checks the age of a patient before showing the menopause question. The age has been adjusted to pick 40yrs and above