### PR TITLE
validations added on the menopause question to support form saving

### DIFF
--- a/configuration/ampathforms/HIV_Green_Card.json
+++ b/configuration/ampathforms/HIV_Green_Card.json
@@ -2416,11 +2416,6 @@
                 },
                 {
                   "type": "js_expression",
-                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(hasLMP) && hasLMP === '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'",
-                  "message": "Required!"
-                },
-                {
-                  "type": "js_expression",
                   "failsWhenExpression": "(new moment(encDate)).isBefore((new moment(myValue)), 'day')",
                   "message": "LMP date should not be greater than the encounter date."
                 },

--- a/configuration/ampathforms/HIV_Green_Card.json
+++ b/configuration/ampathforms/HIV_Green_Card.json
@@ -2374,7 +2374,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "sex !=='F' || (age < 15 || age > 49)"
+                "hideWhenExpression": "sex !=='F' || (age < 15)"
               }
             },
             {
@@ -2397,7 +2397,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "sex !=='F' || (age < 15 || age > 49)"
+                "hideWhenExpression": "sex !=='F' || (age < 15)"
               }
             },
             {


### PR DESCRIPTION
This PR removes the following JS_Expression to allow the form to save

{
                  "type": "js_expression",
                  "failsWhenExpression": "isEmpty(myValue) && !isEmpty(hasLMP) && hasLMP === '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'",
                  "message": "Required!"
                },