### PR TITLE
validate questions for eye assessed to show only when selected

### DIFF
--- a/configuration/ampathforms/Ophthamology_Clinical_Form.json
+++ b/configuration/ampathforms/Ophthamology_Clinical_Form.json
@@ -532,6 +532,10 @@
                 "rendering": "multiCheckbox",
                 "answers": [
                   {
+                    "concept": "160348AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Visual Acuity"
+                  },
+                  {
                     "concept": "148740AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Anisocoria"
                   },
@@ -586,10 +590,6 @@
                   {
                     "concept": "135803AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Upper eye lid retraction"
-                  },
-                  {
-                    "concept": "160348AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "label": "Visual Acuity"
                   },
                   {
                     "concept": "122813AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -674,7 +674,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "isEmpty(EyesFind) && !arrayContains(EyesFind, '160350AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
+                "hideWhenExpression": "isEmpty(EyesFind) || !arrayContains(EyesFind, '160350AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
               }
             },
             {
@@ -713,7 +713,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "isEmpty(EyesFind) && !arrayContains(EyesFind, '160349AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
+                "hideWhenExpression": "isEmpty(EyesFind) || !arrayContains(EyesFind, '160349AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
               }
             },
             {


### PR DESCRIPTION
This PR validates the showing of the right and left eye finding questions by checking which eye been assessed was selected.