### PR TITLE
add variables to support other discharge form use cases

### DIFF
--- a/configuration/ampathforms/Inpatient Discharge Form.json
+++ b/configuration/ampathforms/Inpatient Discharge Form.json
@@ -9,7 +9,7 @@
   "encounter": "IPD Discharge",
   "pages": [
     {
-      "label": "Inpatient Discharge Form",
+      "label": "Encounter Details",
       "sections": [
         {
           "label": "Encounter Details",
@@ -49,6 +49,339 @@
               "id": "encLocation"
             }
           ]
+        }
+      ]
+    },
+    {
+      "label": "Patient Details",
+      "sections": [
+        {
+          "label": "Delivery Details",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Mode of Delivery:",
+              "type": "obs",
+              "id": "deliveryMode",
+              "questionOptions": {
+                "concept": "5630AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "useMostRecentValue": "true",
+                "autoPopulateWithMostRecentValue": "true",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "1170AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Spontaneous vaginal delivery(SVD)"
+                  },
+                  {
+                    "concept": "1171AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Cesarean section(CS)"
+                  },
+                  {
+                    "concept": "1172AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Breech delivery"
+                  },
+                  {
+                    "concept": "118159AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Assisted vaginal delivery(AVD)"
+                  }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            },
+            {
+              "label": "Date and time of Delivery:",
+              "type": "obs",
+              "datePickerFormat": "both",
+              "questionOptions": {
+                "rendering": "date",
+                "concept": "5599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "useMostRecentValue": "true",
+                "autoPopulateWithMostRecentValue": "true"
+              },
+              "id": "deliveryDateTime",
+              "validators": [
+                {
+                  "type": "date",
+                  "allowFutureDates": "false"
+                }
+              ],
+              "required": "true",
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            },
+            {
+              "label": "Blood loss during delivery in millilitres (mls):",
+              "type": "obs",
+              "id": "EstimateDBL",
+              "questionOptions": {
+                "concept": "161928AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "useMostRecentValue": "true",
+                "autoPopulateWithMostRecentValue": "true",
+                "rendering": "number",
+                "min": "0",
+                "max": "500"
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            },
+            {
+              "label": "Complications during labour delivery and after delivery",
+              "type": "obs",
+              "id": "counselledOnInfantFeeding",
+              "questionOptions": {
+                "concept": "CIEL: 1000130",
+                "useMostRecentValue": "true",
+                "autoPopulateWithMostRecentValue": "true",
+                "rendering": "checkbox",
+                "answers": [
+                  {
+                    "concept": "CIEL: 113602",
+                    "label": "Prolonged labour"
+                  },
+                  {
+                    "concept": "CIEL: 115036",
+                    "label": "Obstructed labour"
+                  },
+                  {
+                    "concept": "CIEL: 160854",
+                    "label": "Obstetric fistula"
+                  },
+                  {
+                    "concept": "CIEL: 127253",
+                    "label": "Rapture of the uterus"
+                  },
+                  {
+                    "concept": "CIEL: 118256",
+                    "label": "Fetal distress"
+                  },
+                  {
+                    "concept": "CIEL: 129192",
+                    "label": "Cord presentation and Cord prolapse"
+                  },
+                  {
+                    "concept": "CIEL: 115948",
+                    "label": "Malpresentation and Malpositions"
+                  },
+                  {
+                    "concept": "CIEL: 112980",
+                    "label": "Shoulder dystocia"
+                  },
+                  {
+                    "concept": "CIEL: 230",
+                    "label": "PPH"
+                  }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            },
+            {
+              "label": "Counselled on infant feeding ?",
+              "type": "obs",
+              "id": "counselledOnInfantFeeding",
+              "questionOptions": {
+                "concept": "161651AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "useMostRecentValue": "true",
+                "autoPopulateWithMostRecentValue": "true",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No"
+                  }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            },
+            {
+              "label": "Vitamin A for mother dispensed?",
+              "type": "obs",
+              "id": "vitaminAdispensed",
+              "questionOptions": {
+                "concept": "161534AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "useMostRecentValue": "true",
+                "autoPopulateWithMostRecentValue": "true",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No"
+                  },
+                  {
+                    "concept": "1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "N/A"
+                  }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            },
+            {
+              "label": "Delivery Outcome",
+              "type": "obs",
+              "id": "deliveryOutcome",
+              "questionOptions": {
+                "concept": "159949AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "useMostRecentValue": "true",
+                "autoPopulateWithMostRecentValue": "true",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "159913AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Single"
+                  },
+                  {
+                    "concept": "159914AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Twins"
+                  },
+                  {
+                    "concept": "159915AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Triplets"
+                  }
+                ]
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            },
+            {
+              "label": "Baby(s) details",
+              "type": "obsGroup",
+              "questionOptions": {
+                "concept": "162588AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "group"
+              },
+              "hide": {
+                "hideWhenExpression": "!(age > 0) || !(age < 5)"
+              },
+              "questions": [
+                {
+                  "label": "Immunization Status",
+                  "type": "obs",
+                  "id": "iMMuNHist",
+                  "questionOptions": {
+                    "concept": "164464AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "rendering": "checkbox",
+                    "answers": [
+                      {
+                        "concept": "783AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "Polio"
+                      },
+                      {
+                        "concept": "162586AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "Measles"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "label": "Birth notification number :",
+                  "type": "obs",
+                  "id": "birthNotificationNumber",
+                  "questionOptions": {
+                    "concept": "162051AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "useMostRecentValue": "true",
+                    "autoPopulateWithMostRecentValue": "true",
+                    "rendering": "text"
+                  }
+                },
+                {
+                  "label": "Apgar Score",
+                  "type": "obs",
+                  "id": "babyApgarScore10Min",
+                  "required": "true",
+                  "questionOptions": {
+                    "concept": "159605AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "useMostRecentValue": "true",
+                    "autoPopulateWithMostRecentValue": "true",
+                    "rendering": "number",
+                    "min": "0",
+                    "max": "10"
+                  },
+                  "hide": {
+                    "hideWhenExpression": ""
+                  }
+                }
+              ],
+              "id": "babyDetails"
+            },
+            {
+              "label": "Maternal condition",
+              "type": "obs",
+              "id": "maternalCondition",
+              "questionOptions": {
+                "concept": "162093AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "textarea",
+                "rows": "10"
+              },
+              "hide": {
+                "hideWhenExpression": "sex !== 'F' || !(age > 10) || !(age < 45)"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Patient Outcome",
+      "sections": [
+        {
+          "label": "Discharge Details",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Final Diagnosis",
+              "id": "FinAlDiagnosis",
+              "type": "diagnosis",
+              "questionOptions": {
+                "rendering": "remote-select",
+                "rank": 1,
+                "datasource": {
+                  "name": "diagnoses",
+                  "config": {
+                    "conceptSourceUuid": "39ADDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+                  }
+                }
+              }
+            },
+            {
+              "label": "Discharge date :",
+              "type": "obs",
+              "id": "dischargeDate",
+              "questionOptions": {
+                "concept": "1641AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "date"
+              },
+              "validators": [
+                {
+                  "type": "date",
+                  "allowFutureDates": "false"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "(new moment(encDate)).isAfter((new moment(myValue)), 'day')",
+                  "message": "Discharge date should not be before the encounter date."
+                }
+              ]
+            }
+          ]
         },
         {
           "label": "Clinical summary",
@@ -60,28 +393,21 @@
               "required": false,
               "id": "dischargeInstructions",
               "questionOptions": {
-                "rendering": "text",
+                "rendering": "textarea",
                 "concept": "160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "conceptMappings": [
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "CIEL",
-                    "value": "160632"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "AMPATH",
-                    "value": "1915"
-                  },
-                  {
-                    "relationship": "NARROWER-THAN",
-                    "type": "LOINC",
-                    "value": "48767-8"
-                  }
-                ],
-                "answers": []
+                "rows": "5"
               },
               "validators": []
+            },
+            {
+              "label": "Clinical Notes",
+              "type": "obs",
+              "id": "clinicalNotes",
+              "questionOptions": {
+                "concept": "159395AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "textarea",
+                "rows": "10"
+              }
             },
             {
               "label": "Discharge status",
@@ -91,18 +417,6 @@
               "questionOptions": {
                 "rendering": "select",
                 "concept": "1695AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "conceptMappings": [
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "SNOMED CT",
-                    "value": "309039003"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "CIEL",
-                    "value": "1695"
-                  }
-                ],
                 "answers": [
                   {
                     "concept": "162677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -121,6 +435,10 @@
                     "label": "Referred to higher level facility"
                   },
                   {
+                    "concept": "160483AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Referred to a specialist"
+                  },
+                  {
                     "concept": "159AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "label": "Deceased"
                   }
@@ -129,82 +447,51 @@
               "validators": []
             },
             {
-              "label": "Discharging doctor",
-              "type": "encounterProvider",
-              "required": false,
-              "id": "dischargingDoctor",
+              "label": "Referred to?",
+              "type": "obs",
+              "id": "referredTo",
               "questionOptions": {
-                "rendering": "ui-select-extended",
-                "concept": "1473AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "conceptMappings": [
+                "concept": "163145AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "select",
+                "answers": [
                   {
-                    "relationship": "SAME-AS",
-                    "type": "PIH",
-                    "value": "1392"
+                    "concept": "163488AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Community Unit"
                   },
                   {
-                    "relationship": "SAME-AS",
-                    "type": "CIEL",
-                    "value": "1473"
+                    "concept": "1537AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Another Health Facility"
                   }
-                ],
-                "answers": []
+                ]
               },
-              "validators": []
+              "hide": {
+                "hideWhenExpression": "isEmpty(dischargeStatus) || dischargeStatus !== '164165AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
             },
             {
-              "label": "Follow up date",
-              "type": "obs",
-              "required": false,
-              "id": "followUpDate",
+              "label": "Name of Facility:",
+              "type": "encounterLocation",
+              "required": "true",
               "questionOptions": {
-                "rendering": "date",
-                "concept": "5096AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "conceptMappings": [
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "AMPATH",
-                    "value": "5096"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "SNOMED MVP",
-                    "value": "50961000105000"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "org.openmrs.module.mdrtb",
-                    "value": "RETURN VISIT DATE"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "PIH Malawi",
-                    "value": "5096"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "CIEL",
-                    "value": "5096"
-                  },
-                  {
-                    "relationship": "NARROWER-THAN",
-                    "type": "SNOMED NP",
-                    "value": "406543005"
-                  }
-                ],
-                "answers": []
+                "rendering": "ui-select-extended"
               },
-              "validators": [
-                {
-                  "type": "date",
-                  "allowFutureDates": "true"
-                },
-                {
-                  "type": "js_expression",
-                  "failsWhenExpression": "(new moment(encDate)).isAfter((new moment(myValue)), 'day') || (new moment(encDate)).isSame((new moment(myValue)), 'day')",
-                  "message": "Follow up date should be greater than the encounter date."
-                }
-              ]
+              "id": "OtherFacility",
+              "hide": {
+                "hideWhenExpression": "isEmpty(referredTo) || referredTo !== '1537AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
+            },
+            {
+              "label": "Follow up appointment",
+              "required": false,
+              "id": "appointmentWorkspaceLauncher",
+              "questionOptions": {
+                "rendering": "workspace-launcher",
+                "buttonLabel": "Add appointments",
+                "workspaceName": "appointments-form-workspace"
+              },
+              "hide": {
+                "hideWhenExpression": "isEmpty(dischargeStatus) || dischargeStatus !=='162677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && dischargeStatus !=='160483AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
             },
             {
               "label": "Follow up with (Doctor/Specialist)",
@@ -214,18 +501,6 @@
               "questionOptions": {
                 "rendering": "select",
                 "concept": "167079AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "conceptMappings": [
-                  {
-                    "relationship": "NARROWER-THAN",
-                    "type": "SNOMED CT",
-                    "value": "243796009"
-                  },
-                  {
-                    "relationship": "NARROWER-THAN",
-                    "type": "CIEL",
-                    "value": "167079"
-                  }
-                ],
                 "answers": [
                   {
                     "concept": "160456AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -252,6 +527,20 @@
                     "label": "Nutritionist"
                   }
                 ]
+              },
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "isEmpty(dischargeStatus) || dischargeStatus !== '160483AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+              }
+            },
+            {
+              "label": "Discharging doctor",
+              "type": "encounterProvider",
+              "required": false,
+              "id": "dischargingDoctor",
+              "questionOptions": {
+                "rendering": "ui-select-extended",
+                "concept": "1473AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
               },
               "validators": []
             }


### PR DESCRIPTION
This PR combines all discharge forms into one, with validations of age, sex and condition of patient to support when to show/hide certain variables. It checks Age = 1, >10 and <45 to show certain MCH questions while maintaining a general outlook of admission by Sex == M/F