### PR TITLE
(feat) : add amharic to the allowed locales supported by kenyaemr o3

### DIFF
--- a/configuration/globalproperties/i18n.xml
+++ b/configuration/globalproperties/i18n.xml
@@ -1,0 +1,8 @@
+<config>
+    <globalProperties>
+        <globalProperty>
+            <property>locale.allowed.list</property>
+            <value>en, en_GB, es, fr, he, km, ar, vi, pt, zh, am, sw</value>
+        </globalProperty>
+    </globalProperties>
+</config>


### PR DESCRIPTION
### Description

This adds `amharic` and `swahili` language among the languages supported by kenyaemr(taifa care)