### PR TITLE
Validate the Delivery form to allow user document the baby's name und…

### DIFF
--- a/configuration/ampathforms/Delivery.json
+++ b/configuration/ampathforms/Delivery.json
@@ -1532,7 +1532,7 @@
                     "rendering": "text"
                   },
                   "hide": {
-                    "hideWhenExpression": "isEmpty(babyCondition) || babyCondition !== '159916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || babyCondition !== '135436AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+                    "hideWhenExpression": "isEmpty(babyCondition) || babyCondition === '159916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || babyCondition === '135436AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
                   }
                 },
                 {
@@ -1573,8 +1573,8 @@
                   "questionOptions": {
                     "concept": "1503AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "rendering": "number",
-                    "min": "20",
-                    "max": "200"
+                    "min": "9",
+                    "max": "60"
                   },
                   "hide": {
                     "hideWhenExpression": "isEmpty(babyCondition) || babyCondition === '135436AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"


### PR DESCRIPTION
### Description
Validate the Delivery form to allow user document the baby's name under the baby details section and allow recording of baby birth length to have minimum as 9cm and maximum 60 cm.